### PR TITLE
✨Feat: 가게 엔터티 생성

### DIFF
--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/entity/Store.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/entity/Store.java
@@ -1,0 +1,81 @@
+package com.example.cloudfour.peopleofdelivery.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class Store {
+
+    @Id
+    @GeneratedValue
+    @Column(nullable = false)
+    private UUID storeId;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private UUID regionID;
+
+    @Column(nullable = false)
+    private UUID storeCategoriesId;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(nullable = false, length = 255)
+    private String address;
+
+    private String storePicture;
+
+    @Column(nullable = false, length = 255)
+    private String phone;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private Integer minPrice;
+
+    @Column(nullable = false)
+    private Integer deliveryTip;
+
+    private Float rating;
+
+    private Integer likeCount;
+
+    private Integer reviewCount;
+
+    @Column(nullable = false, length = 255)
+    private String operationHours;
+
+    @Column(nullable = false, length = 255)
+    private String closedDays;
+
+    @Builder
+    public Store(UUID userId, UUID regionID, UUID storeCategoriesId, String name, String address,
+                 String storePicture, String phone, String content, Integer minPrice, Integer deliveryTip,
+                 Float rating, Integer likeCount, Integer reviewCount, String operationHours,
+                 String closedDays) {
+        this.userId = userId;
+        this.regionID = regionID;
+        this.storeCategoriesId = storeCategoriesId;
+        this.name = name;
+        this.address = address;
+        this.storePicture = storePicture;
+        this.phone = phone;
+        this.content = content;
+        this.minPrice = minPrice;
+        this.deliveryTip = deliveryTip;
+        this.rating = rating;
+        this.likeCount = likeCount;
+        this.reviewCount = reviewCount;
+        this.operationHours = operationHours;
+        this.closedDays = closedDays;
+    }
+}


### PR DESCRIPTION
- Store 도메인 엔터티 클래스 생성 (UUID 기반)
- NOT NULL 제약 조건 및 컬럼 설정 적용
- @Builder 사용으로 빌더 패턴 지원

## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

people_of_delivery #9 

<br/>

## 🔎 작업 내용

- Store(가게) 도메인 엔터티 클래스 생성
- UUID 기반 식별자 사용 , JPA 어노테이션 매핑
- 컬럼 제약조건 설정 : NOT NULL , 문자열 길이
- @Builder ->  빌더 패턴 적용

 참고 사항 📌
- 아직 연관 관계는 매핑 X
- `BaseEntity`로 부터 상속 X

