### PR TITLE
✨ [FEAT] 엔티티 전체 연관관계 매핑, builder 수정

### DIFF
--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cart/entity/Cart.java
@@ -1,10 +1,12 @@
 package com.example.cloudfour.peopleofdelivery.domain.cart.entity;
 
 import com.example.cloudfour.peopleofdelivery.domain.cartitem.entity.CartItem;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -19,28 +21,44 @@ import java.util.UUID;
 @Table(name="p_cart")
 public class Cart {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
+    @GeneratedValue
     private UUID id;
 
     @Column(nullable = false)
     private Integer count;
 
+    @CreationTimestamp
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @UpdateTimestamp
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "userId" ,nullable = false)
     private User user;
 
-    // TODO 가게 ManyToOne으로 추가하기
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storeId" ,nullable = false)
+    private Store store;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "cart",cascade = CascadeType.ALL)
     @Builder.Default
     private List<CartItem> cartItems = new ArrayList<>();
+
+    public static class CartBuilder{
+        private CartBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수정 불가");
+        }
+    }
+
+    public void setUser(User user){
+        this.user = user;
+        user.getCarts().add(this);
+    }
+
+    public void setStore(Store store){
+        this.store = store;
+        store.getCarts().add(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cartitem/entity/CartItem.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cartitem/entity/CartItem.java
@@ -1,9 +1,10 @@
 package com.example.cloudfour.peopleofdelivery.domain.cartitem.entity;
 
 import com.example.cloudfour.peopleofdelivery.domain.cart.entity.Cart;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.MenuOption;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 
 import java.util.UUID;
 
@@ -15,11 +16,7 @@ import java.util.UUID;
 @Table(name = "p_cartitem")
 public class CartItem {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
+    @GeneratedValue
     private UUID id;
 
     @Column(nullable = false)
@@ -29,9 +26,35 @@ public class CartItem {
     private Integer price;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "cartId" ,nullable = false)
     private Cart cart;
 
-    //TODO 메뉴, 메뉴 옵션 ManytoOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menuId" ,nullable = false)
+    private Menu menu;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menuOptionId" ,nullable = false)
+    private MenuOption menuOption;
+
+    public static class CartItemBuilder{
+        private CartItemBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수정 불가");
+        }
+    }
+
+    public void setCart(Cart cart){
+        this.cart = cart;
+        cart.getCartItems().add(this);
+    }
+
+    public void setMenu(Menu menu){
+        this.menu = menu;
+        menu.getCartItems().add(this);
+    }
+
+    public void setMenuOption(MenuOption menuOption){
+        this.menuOption = menuOption;
+        menuOption.getCartItems().add(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/MenuCategory.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/MenuCategory.java
@@ -2,43 +2,31 @@ package com.example.cloudfour.peopleofdelivery.domain.menu.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
-@Table(name = "p_menucategories")
+@Table(name = "p_menucategory")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)  // Builder만 사용하도록 제한
 public class MenuCategory {
     @Id
-    @UuidGenerator
-    @Column(name = "menuCategories")
-    private String menuCategories;  // 자동 생성되는 UUID
+    @GeneratedValue
+    private UUID id;  // 자동 생성되는 UUID
 
     @Column(name = "category", nullable = false)
     private String category;
 
-    @OneToMany(mappedBy = "menuCategory", cascade = CascadeType.ALL, orphanRemoval = true)
-    private java.util.List<Menu> menus = new java.util.ArrayList<>();
+    @OneToMany(mappedBy = "menuCategory", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Menu> menus = new ArrayList<>();
 
-    // ID 제외한 필드들만 받는 정적 팩토리 메소드
-    public static MenuCategory createMenuCategory(String category) {
-        if (category == null || category.trim().isEmpty()) {
-            throw new IllegalArgumentException("카테고리명은 필수입니다.");
+    public static class MenuCategoryBuilder{
+        private MenuCategoryBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수정 불가");
         }
-
-        return MenuCategory.builder()
-            .category(category)
-            // menuCategories는 자동 생성됨
-            .build();
-    }
-
-    // 비즈니스 로직을 통한 안전한 변경 메소드
-    public void updateCategory(String category) {
-        if (category == null || category.trim().isEmpty()) {
-            throw new IllegalArgumentException("카테고리명은 필수입니다.");
-        }
-        this.category = category;
     }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/MenuOption.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/MenuOption.java
@@ -1,11 +1,17 @@
 package com.example.cloudfour.peopleofdelivery.domain.menu.entity;
 
+import com.example.cloudfour.peopleofdelivery.domain.cartitem.entity.CartItem;
+import com.example.cloudfour.peopleofdelivery.domain.orderitem.entity.OrderItem;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 @Entity
-@Table(name = "p_menuoptions")
+@Table(name = "p_menuoption")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
@@ -14,11 +20,7 @@ public class MenuOption {
     @Id
     @UuidGenerator
     @Column(name = "menuOptionId")
-    private String menuOptionId;  // 자동 생성되는 UUID
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "menuId", nullable = false)
-    private Menu menu;
+    private UUID id;  // 자동 생성되는 UUID
 
     @Column(name = "optionName", nullable = false)
     private String optionName;
@@ -26,35 +28,26 @@ public class MenuOption {
     @Column(name = "additionalPrice", nullable = false)
     private Integer additionalPrice;  // INT 타입으로 변경
 
-    // ID 제외한 필드들만 받는 정적 팩토리 메소드
-    public static MenuOption createMenuOption(Menu menu, String optionName, Integer additionalPrice) {
-        if (menu == null) {
-            throw new IllegalArgumentException("메뉴는 필수입니다.");
-        }
-        if (optionName == null || optionName.trim().isEmpty()) {
-            throw new IllegalArgumentException("옵션명은 필수입니다.");
-        }
-        if (additionalPrice == null || additionalPrice < 0) {
-            throw new IllegalArgumentException("추가 가격은 0 이상이어야 합니다.");
-        }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menuId", nullable = false)
+    private Menu menu;
 
-        return MenuOption.builder()
-            .menu(menu)
-            .optionName(optionName)
-            .additionalPrice(additionalPrice)
-            // menuOptionId는 자동 생성됨
-            .build();
+    @OneToMany(mappedBy = "menuOption", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    @OneToMany(mappedBy = "menuOption", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    public static class MenuOptionBuilder{
+        private MenuOptionBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수정 불가");
+        }
     }
 
-    // 비즈니스 로직을 통한 안전한 변경 메소드
-    public void updateOptionInfo(String optionName, Integer additionalPrice) {
-        if (optionName == null || optionName.trim().isEmpty()) {
-            throw new IllegalArgumentException("옵션명은 필수입니다.");
-        }
-        if (additionalPrice == null || additionalPrice < 0) {
-            throw new IllegalArgumentException("추가 가격은 0 이상이어야 합니다.");
-        }
-        this.optionName = optionName;
-        this.additionalPrice = additionalPrice;
+    public void setMenu(Menu menu){
+        this.menu = menu;
+        menu.getMenuOptions().add(this);
     }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/enums/MenuStatus.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/enums/MenuStatus.java
@@ -1,4 +1,4 @@
-package com.example.cloudfour.peopleofdelivery.domain.menu.entity;
+package com.example.cloudfour.peopleofdelivery.domain.menu.enums;
 
 public enum MenuStatus {
     판매중,

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/entity/Order.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/entity/Order.java
@@ -3,12 +3,15 @@ package com.example.cloudfour.peopleofdelivery.domain.order.entity;
 import com.example.cloudfour.peopleofdelivery.domain.order.enums.OrderStatus;
 import com.example.cloudfour.peopleofdelivery.domain.order.enums.OrderType;
 import com.example.cloudfour.peopleofdelivery.domain.order.enums.ReceiptType;
+import com.example.cloudfour.peopleofdelivery.domain.orderitem.entity.OrderItem;
 import com.example.cloudfour.peopleofdelivery.domain.payment.entity.Payment;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -17,13 +20,9 @@ import java.util.UUID;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Table(name = "p_order")
-public class Order {
+public class Order{
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
+    @GeneratedValue
     private UUID id;
 
     @Enumerated(EnumType.STRING)
@@ -47,8 +46,12 @@ public class Order {
     private OrderStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "userId", nullable = false)
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storeId", nullable = false)
+    private Store store;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Payment payment;
@@ -56,5 +59,31 @@ public class Order {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private OrderHistory orderHistory;
 
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<OrderItem> orderItems = new ArrayList<>();
 
+    public static class OrderBuilder{
+        private OrderBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
+
+    public void setUser(User user){
+        this.user = user;
+        user.getOrders().add(this);
+    }
+
+    public void setStore(Store store){
+        this.store = store;
+        store.getOrders().add(this);
+    }
+
+    public void setPayment(Payment payment){
+        this.payment = payment;
+    }
+
+    public void setOrderHistory(OrderHistory orderHistory){
+        this.orderHistory = orderHistory;
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/entity/OrderHistory.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/entity/OrderHistory.java
@@ -4,16 +4,14 @@ import com.example.cloudfour.peopleofdelivery.domain.order.enums.OrderStatus;
 import com.example.cloudfour.peopleofdelivery.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
-
 import java.util.UUID;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@SuperBuilder
-@Table(name = "p_orderhistory")
+@Builder
+@Table(name = "p_order_history")
 public class OrderHistory extends BaseEntity {
     @Id
     @GeneratedValue
@@ -26,4 +24,15 @@ public class OrderHistory extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "orderId" ,nullable = false)
     private Order order;
+
+    public static class OrderHistoryBuilder{
+        private OrderHistoryBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
+
+    public void setOrder(Order order){
+        this.order = order;
+        order.setOrderHistory(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/orderitem/entity/OrderItem.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/orderitem/entity/OrderItem.java
@@ -1,10 +1,10 @@
 package com.example.cloudfour.peopleofdelivery.domain.orderitem.entity;
 
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.MenuOption;
 import com.example.cloudfour.peopleofdelivery.domain.order.entity.Order;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
-
 import java.util.UUID;
 
 @Entity
@@ -12,14 +12,10 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@Table(name = "orderitem")
+@Table(name = "p_orderItem")
 public class OrderItem {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
+    @GeneratedValue
     private UUID id;
 
     private Integer quantity;
@@ -27,8 +23,35 @@ public class OrderItem {
     private Integer price;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "orderId", nullable = false)
     private Order order;
 
-    //TODO: 메뉴, 메뉴옵션 ManyToOne 추가
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menuId", nullable = false)
+    private Menu menu;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menuOptionId", nullable = false)
+    private MenuOption menuOption;
+
+    public static class OrderItemBuilder{
+        private OrderItemBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수정 불가");
+        }
+    }
+
+    public void setOrder(Order order){
+        this.order = order;
+        order.getOrderItems().add(this);
+    }
+
+    public void setMenu(Menu menu){
+        this.menu = menu;
+        menu.getOrderItems().add(this);
+    }
+
+    public void setMenuOption(MenuOption menuOption){
+        this.menuOption = menuOption;
+        menuOption.getOrderItems().add(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/entity/Payment.java
@@ -4,9 +4,7 @@ import com.example.cloudfour.peopleofdelivery.domain.order.entity.Order;
 import com.example.cloudfour.peopleofdelivery.domain.payment.enums.PaymentStatus;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -17,11 +15,7 @@ import java.util.UUID;
 @Table(name = "p_payment")
 public class Payment {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
+    @GeneratedValue
     private UUID id;
 
     @Column(nullable = false)
@@ -37,9 +31,6 @@ public class Payment {
     @Column(nullable = false)
     private PaymentStatus paymentStatus;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
     @Lob
     private String failedReason;
 
@@ -47,7 +38,22 @@ public class Payment {
     private PaymentHistory paymentHistory;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name ="orderId", nullable = false)
     private Order order;
+
+    public static class PaymentBuilder{
+        private PaymentBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
+
+    public void setPaymentHistory(PaymentHistory paymentHistory){
+        this.paymentHistory = paymentHistory;
+    }
+
+    public void setOrder(Order order){
+        this.order = order;
+        order.setPayment(this);
+    }
 }
 

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/entity/PaymentHistory.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/entity/PaymentHistory.java
@@ -4,16 +4,14 @@ import com.example.cloudfour.peopleofdelivery.domain.payment.enums.PaymentStatus
 import com.example.cloudfour.peopleofdelivery.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
-
 import java.util.UUID;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@SuperBuilder
-@Table(name = "p_paymenthistory")
+@Builder
+@Table(name = "p_payment_history")
 public class PaymentHistory extends BaseEntity {
     @Id
     @GeneratedValue
@@ -29,4 +27,15 @@ public class PaymentHistory extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "paymentId", nullable = false)
     private Payment payment;
+
+    public static class PaymentHistoryBuilder{
+        private PaymentHistoryBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
+
+    public void setPayment(Payment payment){
+        this.payment = payment;
+        payment.setPaymentHistory(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/region/entity/Region.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/region/entity/Region.java
@@ -1,9 +1,9 @@
 package com.example.cloudfour.peopleofdelivery.domain.region.entity;
 
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import com.example.cloudfour.peopleofdelivery.domain.useraddress.entity.UserAddress;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,11 +17,7 @@ import java.util.UUID;
 @Table(name = "p_region")
 public class Region {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
+    @GeneratedValue
     private UUID id;
 
     @Column(nullable = false)
@@ -37,5 +33,14 @@ public class Region {
     @Builder.Default
     private List<UserAddress> addresses = new ArrayList<>();
 
-    //TODO: 가게 OneToMany 추가
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "region", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Store> stores = new ArrayList<>();
+
+    public static class RegionBuilder{
+        private RegionBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수정 불가");
+        }
+    }
+
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/review/entity/Review.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/review/entity/Review.java
@@ -1,18 +1,18 @@
 package com.example.cloudfour.peopleofdelivery.domain.review.entity;
 
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
 import com.example.cloudfour.peopleofdelivery.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
-
 import java.util.UUID;
 
 @Entity
 @Getter
-@SuperBuilder
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_review")
 public class Review extends BaseEntity {
     @Id
@@ -31,4 +31,33 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false)
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menuId", nullable = false)
+    private Menu menu;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storeId", nullable = false)
+    private Store store;
+
+    public static class ReviewBuilder{
+        private ReviewBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
+
+    public void setUser(User user){
+        this.user = user;
+        user.getReviews().add(this);
+    }
+
+    public void setMenu(Menu menu){
+        this.menu = menu;
+        menu.getReviews().add(this);
+    }
+
+    public void setStore(Store store){
+        this.store = store;
+        store.getReviews().add(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/entity/Store.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/entity/Store.java
@@ -1,26 +1,29 @@
 package com.example.cloudfour.peopleofdelivery.domain.store.entity;
 
+import com.example.cloudfour.peopleofdelivery.domain.cart.entity.Cart;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
+import com.example.cloudfour.peopleofdelivery.domain.order.entity.Order;
+import com.example.cloudfour.peopleofdelivery.domain.region.entity.Region;
+import com.example.cloudfour.peopleofdelivery.domain.review.entity.Review;
+import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
 import com.example.cloudfour.peopleofdelivery.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@SuperBuilder
+@Builder
 @Table(name = "p_store")
 public class Store extends BaseEntity {
     @Id
     @GeneratedValue
     private UUID id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "storeCategoriesId", nullable = false)
-    private StoreCategory storeCategory;
 
     @Column(nullable = false, length = 255)
     private String name;
@@ -53,4 +56,53 @@ public class Store extends BaseEntity {
 
     @Column(nullable = false, length = 255)
     private String closedDays;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storeCategoryId", nullable = false)
+    private StoreCategory storeCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "regionId", nullable = false)
+    private Region region;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "store", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "store", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Cart> carts = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "store", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Order> orders = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "store", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Menu> menus = new ArrayList<>();
+    
+    public static class StoreBuilder {
+        private StoreBuilder id(UUID id) {
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
+
+    public void setStoreCategory(StoreCategory storeCategory) {
+        this.storeCategory = storeCategory;
+        storeCategory.getStores().add(this);
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        user.getStores().add(this);
+    }
+
+    public void setRegion(Region region) {
+        this.region = region;
+        region.getStores().add(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/entity/StoreCategory.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/entity/StoreCategory.java
@@ -10,23 +10,26 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = "stores")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "p_storecategory")
 public class StoreCategory {
-
     @Id
     @GeneratedValue
     @Column(nullable = false)
-    private UUID storeCategoriesId;
+    private UUID id;
 
     @Column(nullable = false, length = 255)
     private String category;
 
     // 🔽 양방향 관계 추가
     @OneToMany(mappedBy = "storeCategory", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Store> stores = new ArrayList<>();
 
-    @Builder
-    public StoreCategory(String category) {
-        this.category = category;
+    public static class StoreCategoryBuilder {
+        private StoreCategoryBuilder id(UUID id){
+            throw new UnsupportedOperationException("id 생성 불가");
+        }
     }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/user/entity/User.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/user/entity/User.java
@@ -3,12 +3,12 @@ package com.example.cloudfour.peopleofdelivery.domain.user.entity;
 import com.example.cloudfour.peopleofdelivery.domain.cart.entity.Cart;
 import com.example.cloudfour.peopleofdelivery.domain.order.entity.Order;
 import com.example.cloudfour.peopleofdelivery.domain.review.entity.Review;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import com.example.cloudfour.peopleofdelivery.domain.user.enums.Role;
 import com.example.cloudfour.peopleofdelivery.domain.useraddress.entity.UserAddress;
 import com.example.cloudfour.peopleofdelivery.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@SuperBuilder
+@Builder
 @Table(name = "p_user")
 public class User extends BaseEntity {
     @Id
@@ -53,4 +53,14 @@ public class User extends BaseEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Order> orders = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Store> stores = new ArrayList<>();
+
+    public static class UserBuilder {
+        private UserBuilder id(UUID id) {
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/useraddress/entity/UserAddress.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/useraddress/entity/UserAddress.java
@@ -4,7 +4,6 @@ import com.example.cloudfour.peopleofdelivery.domain.region.entity.Region;
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 
 import java.util.UUID;
 
@@ -16,21 +15,33 @@ import java.util.UUID;
 @Table(name = "p_useraddress")
 public class UserAddress {
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(
-            name = "UUID",
-            strategy = "org.hibernate.id.UUIDGenerator"
-    )
+    @GeneratedValue
     private UUID id;
 
     @Column(nullable = false)
     private String address;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "userId", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "regionId", nullable = false)
     private Region region;
+
+    public static class UserAddressBuilder {
+        private UserAddressBuilder id(UUID id) {
+            throw new UnsupportedOperationException("id 수동 생성 불가");
+        }
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+        user.getAddresses().add(this);
+    }
+
+    public void setRegion(Region region) {
+        this.region = region;
+        region.getAddresses().add(this);
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/global/ai/entity/AiLog.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/global/ai/entity/AiLog.java
@@ -3,7 +3,6 @@ package com.example.cloudfour.peopleofdelivery.global.ai.entity;
 import com.example.cloudfour.peopleofdelivery.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
 
 import java.util.UUID;
 
@@ -11,7 +10,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@SuperBuilder
+@Builder
 @Table(name = "p_ailog")
 public class AiLog extends BaseEntity {
     @Id
@@ -28,4 +27,10 @@ public class AiLog extends BaseEntity {
 
     @Lob
     private String options;
+
+    public static class AiLogBuilder {
+        private AiLogBuilder id(UUID id) {
+            throw new UnsupportedOperationException("id 생성 불가");
+        }
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/global/entity/BaseEntity.java
@@ -3,7 +3,6 @@ package com.example.cloudfour.peopleofdelivery.global.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -12,7 +11,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
-@SuperBuilder
 @MappedSuperclass
 @NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)


### PR DESCRIPTION
## 🔘Part

- [x] 엔티티 전체 연관관계 매핑, 연관관계 메서드 작성
- [x] builder id 메소드 재정의 -> 외부에서 id 수정 못하도록
- [x] baseEntity에 superbuilder 제거 

  <br/>
## ➕ 이슈 링크

- #25 

<br/>

## 🔎 작업 내용

- BaseEntity에 @SuperBuilder 삭제 bcf4140e51213822fe64d92c3fd5304fa9f6e194
- 연관관계 매핑
- 연관관계 메서드 작성
- builder id 메소드 재정의 -> 외부에서 id 값 넣지 못하도록

### builder id 메소드 재정의는 노션 트러블 슈팅에 정리해놨습니다 !!

  <br/>

## 이미지 첨부

### 연관관계 메서드
jpa를 통해 데이터를 찾을 때 1차 캐시에서 먼저 가져오는데 1차 캐시는 jpa, 자바 객체 상태를 참조하는 특성
db와 자바 객체 상태가 불일치 하면 문제 발생
db와 자바 객체 상태를 일관되게 유지해주기 위해 연관관계 메서드를 사용

### ERD
<img width="1029" height="284" alt="image" src="https://github.com/user-attachments/assets/abb769a8-f3af-441c-8aa8-2b3c911a469a" />
User(1) : UserAddress(N) 관계
UserAddress에서 User를 추가하면 User의 List<UserAddress>에도 UserAddress를 추가해줘야 함

### UserAddress
<img width="440" height="103" alt="image" src="https://github.com/user-attachments/assets/be62dc6a-47f0-4660-83bb-36cdcc5b340e" />

추후에 Service계층에서 많이 사용함

<br/>
