### PR TITLE
✨ [FEAT] 엔티티 에러 코드

### DIFF
--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cart/exception/CartErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.cart.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum CartErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "CART400_1", "장바구니 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "CART400_2", "장바구니 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "CART400_3", "장바구니 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "CART401", "장바구니에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "CART404", "장바구니를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "CART409", "이미 등록된 장바구니입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CART500", "장바구니 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cart/exception/CartException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cart/exception/CartException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.cart.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class CartException extends CustomException {
+    public CartException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cartitem/exception/CartItemErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cartitem/exception/CartItemErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.cartitem.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum CartItemErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "CARTITEM400_1", "장바구니 아이템 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "CARTITEM400_2", "장바구니 아이템 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "CARTITEM400_3", "장바구니 아이템 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "CARTITEM401", "장바구니 아이템에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "CARTITEM404", "장바구니 아이템을 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "CARTITEM409", "이미 등록된 장바구니 아이템입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CARTITEM500", "장바구니 아이템 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cartitem/exception/CartItemException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/cartitem/exception/CartItemException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.cartitem.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class CartItemException extends CustomException {
+    public CartItemException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuCategoryErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuCategoryErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum MenuCategoryErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "MENUCATEGORY400_1", "메뉴 카테고리 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "MENUCATEGORY400_2", "메뉴 카테고리 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "MENUCATEGORY400_3", "메뉴 카테고리 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "MENUCATEGORY401", "메뉴 카테고리에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "MENUCATEGORY404", "메뉴 카테고리를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "MENUCATEGORY409", "이미 등록된 메뉴 카테고리입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MENUCATEGORY500", "메뉴 카테고리 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuCategoryException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuCategoryException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class MenuCategoryException extends CustomException {
+    public MenuCategoryException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum MenuErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "MENU400_1", "메뉴 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "MENU400_2", "메뉴 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "MENU400_3", "메뉴 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "MENU401", "메뉴에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "MENU404", "메뉴를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "MENU409", "이미 등록된 메뉴입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MENU500", "메뉴 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class MenuException extends CustomException {
+    public MenuException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuOptionErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuOptionErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum MenuOptionErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "MENUOPTION400_1", "메뉴 옵션 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "MENUOPTION400_2", "메뉴 옵션 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "MENUOPTION400_3", "메뉴 옵션 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "MENUOPTION401", "메뉴 옵션에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "MENUOPTION404", "메뉴 옵션을 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "MENUOPTION409", "이미 등록된 메뉴 옵션입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MENUOPTION500", "메뉴 옵션 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuOptionException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/exception/MenuOptionException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class MenuOptionException extends CustomException {
+    public MenuOptionException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.order.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum OrderErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "ORDER400_1", "주문 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "ORDER400_2", "주문 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "ORDER400_3", "주문 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "ORDER401", "주문에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER404", "주문을 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "ORDER409", "이미 등록된 주문입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ORDER500", "주문 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.order.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class OrderException extends CustomException {
+    public OrderException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderHistoryErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderHistoryErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.order.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum OrderHistoryErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "ORDERHISTORY400_1", "주문 히스토리 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "ORDERHISTORY400_2", "주문 히스토리정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "ORDERHISTORY400_3", "주문 히스토리 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "ORDERHISTORY401", "주문 히스토리에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "ORDERHISTORY404", "주문 히스토리를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "ORDERHISTORY409", "이미 등록된 주문 히스토리입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ORDERHISTORY500", "주문 히스토리 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderHistoryException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/order/exception/OrderHistoryException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.order.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class OrderHistoryException extends CustomException {
+    public OrderHistoryException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/orderitem/exception/OrderItemErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/orderitem/exception/OrderItemErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.orderitem.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum OrderItemErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "ORDERITEM400_1", "주문 아이템 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "ORDERITEM400_2", "주문 아이템 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "ORDERTEM400_3", "주문 아이템 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "ORDERITEM401", "주문 아이템에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "ORDERITEM404", "주문 아이템을 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "ORDERITEM409", "이미 등록된 주문 아이템입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ORDERITEM500", "주문 아이템 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/orderitem/exception/OrderItemException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/orderitem/exception/OrderItemException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.orderitem.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class OrderItemException extends CustomException {
+    public OrderItemException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.payment.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum PaymentErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT400_1", "결제 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT400_2", "결제 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT400_3", "결제 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "PAYMENT401", "결제에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT404", "결제를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "PAYMENT409", "이미 등록된 결제입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT500", "결제 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.payment.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class PaymentException extends CustomException {
+    public PaymentException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentHistoryErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentHistoryErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.payment.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum PaymentHistoryErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENTHISTORY400_1", "결제 히스토리 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENTHISTORY400_2", "결제 히스토리 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENTHISTORY400_3", "결제 히스토리 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "PAYMENTHISTORY401", "결제 히스토리에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENTHISTORY404", "결제 히스토리를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "PAYMENTHISTORY409", "이미 등록된 결제 히스토리입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENTHISTORY500", "결제 히스토리 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentHistoryException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/payment/exception/PaymentHistoryException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.payment.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class PaymentHistoryException extends CustomException {
+    public PaymentHistoryException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/region/exception/RegionErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/region/exception/RegionErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.region.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum RegionErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "REGION400_1", "지역 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "REGION400_2", "지역 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "REGION400_3", "지역 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "REGION401", "지역에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "REGION404", "지역을 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "REGION409", "이미 등록된 지역입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REGION500", "지역 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/region/exception/RegionException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/region/exception/RegionException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.region.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class RegionException extends CustomException {
+    public RegionException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/review/exception/ReviewErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.review.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ReviewErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "REVIEW400_1", "리뷰 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "REVIEW400_2", "리뷰 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "REVIEW400_3", "리뷰 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "REVIEW401", "리뷰에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404", "리뷰를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "REVIEW409", "이미 등록된 리뷰입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REVIEW500", "리뷰 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/review/exception/ReviewException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/review/exception/ReviewException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.review.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class ReviewException extends CustomException {
+    public ReviewException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreCategoryErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreCategoryErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.store.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum StoreCategoryErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "STORECATEGORY400_1", "가게 카테고리 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "STORECATEGORY400_2", "가게 카테고리 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "STORECATEGORY400_3", "가게 카테고리 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "STORECATEGORY401", "가게 카테고리에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "STORECATEGORY404", "가게 카테고리를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "STORECATEGORY409", "이미 등록된 가게 카테고리입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "STORECATEGORY500", "가게 카테고리 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreCategoryException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreCategoryException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.store.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class StoreCategoryException extends CustomException {
+    public StoreCategoryException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.store.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum StoreErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "STORE400_1", "가게 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "STORE400_2", "가게 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "STORE400_3", "가게 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "STORE401", "가게에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "STORE404", "가게를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "STORE409", "이미 등록된 가게입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "STORE500", "가게 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/exception/StoreException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.store.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class StoreException extends CustomException {
+    public StoreException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.user.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum UserErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "USER400_1", "회원 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "USER400_2", "회원 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "USER400_3", "회원 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "USER401", "회원에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "회원을 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "USER409", "이미 등록된 회원입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "USER500", "회원 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/user/exception/UserException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.user.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class UserException extends CustomException {
+    public UserException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/useraddress/exception/UserAddressErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/useraddress/exception/UserAddressErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.domain.useraddress.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum UserAddressErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "USERADDRESS400_1", "회원 주소 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "USERADDRESS400_2", "회원 주소 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "USERADDRESS400_3", "회원 주소 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "USERADDRESS401", "회원 주소에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "USERADDRESS404", "회원 주소를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "USERADDRESS409", "이미 등록된 회원 주소입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "USERADDRESS500", "회원 주소 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/useraddress/exception/UserAddressException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/useraddress/exception/UserAddressException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.domain.useraddress.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class UserAddressException extends CustomException {
+    public UserAddressException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/global/ai/exception/AiLogErrorCode.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/global/ai/exception/AiLogErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.cloudfour.peopleofdelivery.global.ai.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum AiLogErrorCode implements BaseErrorCode {
+    CREATE_FAILED(HttpStatus.BAD_REQUEST, "AILOG400_1", "AI 로그 정보를 생성할 수 없습니다."),
+    UPDATE_FAILED(HttpStatus.BAD_REQUEST, "AILOG400_2", "AI 로그 정보를 수정할 수 없습니다."),
+    DELETE_FAILED(HttpStatus.BAD_REQUEST, "AILOG400_3", "AI 로그 정보를 삭제할 수 없습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "AILOG401", "AI 로그에 접근할 수 있는 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "AILOG404", "AI 로그를 찾을 수 없습니다."),
+    ALREADY_ADD(HttpStatus.CONFLICT, "AILOG409", "이미 등록된 AI 로그입니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AILOG500", "AI 로그 처리 중 서버 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/global/ai/exception/AiLogException.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/global/ai/exception/AiLogException.java
@@ -1,0 +1,10 @@
+package com.example.cloudfour.peopleofdelivery.global.ai.exception;
+
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.code.BaseErrorCode;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.exception.CustomException;
+
+public class AiLogException extends CustomException {
+    public AiLogException(BaseErrorCode errorCode) {
+      super(errorCode);
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x]  엔티티 에러 코드 구현

  <br/>
## ➕ 이슈 링크

- #27 

<br/>

## 🔎 작업 내용

각 엔티티에서 발생하는 모든 오류를 정리한 에러 코드 구현

  <br/>

## 이미지 첨부

### User 예외처리 예시
<img width="505" height="70" alt="image" src="https://github.com/user-attachments/assets/cbcda09b-46bf-442c-9281-ffe278e38145" />

회원가입 하려는 회원의 이메일이 중복되었을 때 UserErrorCode, UserException을 사용하여 예외처리


### 실패했을 경우 응답 ( 다른 프로젝트 예시 )

![image](https://github.com/user-attachments/assets/5aaf71ba-6330-4867-b6cd-2cbdb2ff6495)

### 성공했을 경우 응답 ( 다른 프로젝트 예시 )

![image](https://github.com/user-attachments/assets/d6d686de-8164-448a-9bec-889d0317eeaf)

<br/>
