### PR TITLE
🐛 [FIX] 메뉴-리뷰 연관관계 오류

### DIFF
--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/Menu.java
@@ -2,8 +2,7 @@ package com.example.cloudfour.peopleofdelivery.domain.menu.entity;
 
 import com.example.cloudfour.peopleofdelivery.domain.cartitem.entity.CartItem;
 import com.example.cloudfour.peopleofdelivery.domain.menu.enums.MenuStatus;
-import com.example.cloudfour.peopleofdelivery.domain.orderitem.entity.OrderItem;
-import com.example.cloudfour.peopleofdelivery.domain.review.entity.Review;
+import com.example.cloudfour.peopleofdelivery.domain.order.entity.OrderItem;
 import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import jakarta.persistence.*;
 import lombok.*;
@@ -60,10 +59,6 @@ public class Menu {
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL)
     @Builder.Default
     private List<MenuOption> menuOptions = new ArrayList<>();
-
-    @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL)
-    @Builder.Default
-    private List<Review> reviews = new ArrayList<>();
 
     @OneToMany(mappedBy = "menu", cascade = CascadeType.ALL)
     @Builder.Default


### PR DESCRIPTION
- 메뉴에서 리뷰 연관관계 제거

## 🔘Part

- [x]  메뉴-리뷰 연관관계 삭제

  <br/>
## ➕ 이슈 링크

- #49 

<br/>

## 🔎 작업 내용

메뉴와 리뷰 연관관계 삭제 했는데 리뷰쪽에서 남아있었음
연관관계 삭제

  <br/>

## 이미지 첨부

<br/>
