### PR TITLE
✨ [FEAT] 메뉴 관련 엔티티 MVC 구현

### DIFF
--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
@@ -44,10 +44,8 @@ import java.util.UUID;
 @RequestMapping("/api/menus")   // API의 기본 경로 설정
 @Tag(name = "Menu", description = "메뉴 API by 정병민")  // Swagger에서 사용할 태그
 public class MenuController {
-    private final MenuCommandServiceImpl menuCommandService;    // 메뉴 생성, 수정, 삭제 등의 서비스
-    private final MenuQueryServiceImpl menuQueryService;    // 메뉴 조회 서비스
-    // command 서비스: 데이터를 변경하는 작업
-    // query 서비스: 데이터를 조회하는 작업
+    private final MenuCommandServiceImpl menuCommandService;
+    private final MenuQueryServiceImpl menuQueryService;
 
     @PostMapping("")    // 메뉴 생성 API, HTTP POST 메소드 사용
     @Operation(summary = "메뉴 생성", description = "메뉴를 생성합니다. 메뉴 생성에 사용되는 API입니다.")   // Swagger에서 사용할 설명
@@ -55,7 +53,8 @@ public class MenuController {
             @RequestBody MenuRequestDTO.MenuCreateRequestDTO requestDTO,
             @AuthenticationPrincipal User user) {  // JSON 요청 본문을 MenuCreateRequestDTO로 매핑
 
-        log.info("메뉴 생성 요청 - userId: {}, storeName: {}", user.getId(), requestDTO.getName());
+        log.info("메뉴 생성 요청 - userId: {}, menuName: {}", user.getId(), requestDTO.getName());
+
         MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.createMenu(requestDTO, user);
         return CustomResponse.onSuccess(HttpStatus.CREATED, result);
     }
@@ -68,6 +67,7 @@ public class MenuController {
             @AuthenticationPrincipal User user) {
 
         log.info("메뉴 수정 요청 - userId: {}, menuId: {}", user.getId(), menuId);
+
         MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.updateMenu(menuId, requestDTO, user);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
@@ -79,16 +79,18 @@ public class MenuController {
             @AuthenticationPrincipal User user) {
 
         log.info("메뉴 삭제 요청 - userId: {}, menuId: {}", user.getId(), menuId);
+
         menuCommandService.deleteMenu(menuId, user);
         return CustomResponse.onSuccess(HttpStatus.OK, "메뉴 삭제 완료");
     }
 
     @GetMapping("/{storeId}")
-    @Operation(summary = "해당 가게 메뉴 목록 조회", description = "가게의 메뉴 목록을 조회합니다. 해당 가게의 메뉴를 조회하는 API입니다.")
+    @Operation(summary = "해당 ���게 메뉴 목록 조회", description = "가게의 메뉴 목록을 조회합니다. 해당 가게의 메뉴를 조회하는 API입니다.")
     public CustomResponse<List<MenuResponseDTO.MenuListResponseDTO>> getMenusByStore(
             @PathVariable("storeId") UUID storeId) {
 
         log.info("가게별 메뉴 조회 요청 - storeId: {}", storeId);
+
         List<MenuResponseDTO.MenuListResponseDTO> result = menuQueryService.getMenusByStore(storeId);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
@@ -97,6 +99,7 @@ public class MenuController {
     @Operation(summary = "인기 메뉴 TOP20 조회", description = "인기 메뉴 TOP20을 조회합니다. 인기 메뉴 조회에 사용되는 API입니다.")
     public CustomResponse<List<MenuResponseDTO.MenuTopResponseDTO>> getTopMenus() {
         log.info("인기 메뉴 TOP20 조회 요청");
+
         List<MenuResponseDTO.MenuTopResponseDTO> result = menuQueryService.getTopMenus();
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
@@ -105,6 +108,7 @@ public class MenuController {
     @Operation(summary = "시간대별 인기 메뉴 TOP20 조회", description = "시간대별 인기 메뉴 TOP20을 조회합니다. 시간대별 인기 메뉴 조회에 사용되는 API입니다.")
     public CustomResponse<List<MenuResponseDTO.MenuTimeTopResponseDTO>> getTimeTopMenus() {
         log.info("시간대별 인기 메뉴 TOP20 조회 요청");
+
         List<MenuResponseDTO.MenuTimeTopResponseDTO> result = menuQueryService.getTimeTopMenus();
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
@@ -113,6 +117,7 @@ public class MenuController {
     @Operation(summary = "지역별 인기 메뉴 TOP20 조회", description = "지역별 인기 메뉴 TOP20을 조회합니다. 지역별 인기 메뉴 조회에 사용되는 API입니다.")
     public CustomResponse<List<MenuResponseDTO.MenuRegionTopResponseDTO>> getRegionTopMenus() {
         log.info("지역별 인기 메뉴 TOP20 조회 요청");
+
         List<MenuResponseDTO.MenuRegionTopResponseDTO> result = menuQueryService.getRegionTopMenus();
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }
@@ -123,6 +128,7 @@ public class MenuController {
             @PathVariable("menuId") UUID menuId) {
 
         log.info("메뉴 상세 조회 요청 - menuId: {}", menuId);
+
         MenuResponseDTO.MenuDetailResponseDTO result = menuQueryService.getMenuDetail(menuId);
         return CustomResponse.onSuccess(HttpStatus.OK, result);
     }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
@@ -1,0 +1,129 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.controller;
+
+import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuRequestDTO;
+import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
+import com.example.cloudfour.peopleofdelivery.domain.menu.service.command.MenuCommandServiceImpl;
+import com.example.cloudfour.peopleofdelivery.domain.menu.service.query.MenuQueryServiceImpl;
+import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
+import com.example.cloudfour.peopleofdelivery.global.apiPayLoad.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/*
+ < HTTP 상태 코드 >
+  - 201 CREATED: 성공적으로 생성됨
+  - 200 OK: 성공적으로 처리됨
+  - 400 BAD REQUEST: 잘못된 요청
+  - 500 INTERNAL SERVER ERROR: 서버 내부 오류
+
+ < GET, POST, PUT, PATCH, DELETE 메소드 >
+  - GET: 데이터 조회
+  - POST: 새로운 데이터를 생성
+  - PUT: 기존 데이터를 전체적으로 수정
+  - PATCH: 기존 데이터를 삭제하지 않고 일부 수정
+  - DELETE: 기존 데이터를 삭제
+
+ < Swagger 주석 >
+  - @Operation: API의 동작을 설명
+  - @Tag: API 그룹화 및 설명
+  - @RequestBody: 요청 본문을 DTO로 매핑
+  - @PathVariable: URL 경로에 변수 매핑
+ */
+
+@Slf4j
+@RestController // API를 요청하면 JSON으로 응답
+@RequiredArgsConstructor    // final 필드를 생성자 주입 방식으로 초기화
+@RequestMapping("/api/menus")   // API의 기본 경로 설정
+@Tag(name = "Menu", description = "메뉴 API by 정병민")  // Swagger에서 사용할 태그
+public class MenuController {
+    private final MenuCommandServiceImpl menuCommandService;    // 메뉴 생성, 수정, 삭제 등의 서비스
+    private final MenuQueryServiceImpl menuQueryService;    // 메뉴 조회 서비스
+    // command 서비스: 데이터를 변경하는 작업
+    // query 서비스: 데이터를 조회하는 작업
+
+    @PostMapping("")    // 메뉴 생성 API, HTTP POST 메소드 사용
+    @Operation(summary = "메뉴 생성", description = "메뉴를 생성합니다. 메뉴 생성에 사용되는 API입니다.")   // Swagger에서 사용할 설명
+    public CustomResponse<MenuResponseDTO.MenuDetailResponseDTO> createMenu(
+            @RequestBody MenuRequestDTO.MenuCreateRequestDTO requestDTO,
+            @AuthenticationPrincipal User user) {  // JSON 요청 본문을 MenuCreateRequestDTO로 매핑
+
+        log.info("메뉴 생성 요청 - userId: {}, storeName: {}", user.getId(), requestDTO.getName());
+        MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.createMenu(requestDTO, user);
+        return CustomResponse.onSuccess(HttpStatus.CREATED, result);
+    }
+
+    @PatchMapping("/{menuId}")
+    @Operation(summary = "메뉴 수정", description = "메뉴를 수정합니다. 메뉴 수정에 사용되는 API입니다.")
+    public CustomResponse<MenuResponseDTO.MenuDetailResponseDTO> updateMenu(
+            @PathVariable("menuId") UUID menuId,
+            @RequestBody MenuRequestDTO.MenuUpdateRequestDTO requestDTO,
+            @AuthenticationPrincipal User user) {
+
+        log.info("메뉴 수정 요청 - userId: {}, menuId: {}", user.getId(), menuId);
+        MenuResponseDTO.MenuDetailResponseDTO result = menuCommandService.updateMenu(menuId, requestDTO, user);
+        return CustomResponse.onSuccess(HttpStatus.OK, result);
+    }
+
+    @PatchMapping("/{menuId}/delete")
+    @Operation(summary = "메뉴 삭제", description = "메뉴를 삭제합니다. 메뉴 삭제에 사용되는 API입니다.")
+    public CustomResponse<String> deleteMenu(
+            @PathVariable("menuId") UUID menuId,
+            @AuthenticationPrincipal User user) {
+
+        log.info("메뉴 삭제 요청 - userId: {}, menuId: {}", user.getId(), menuId);
+        menuCommandService.deleteMenu(menuId, user);
+        return CustomResponse.onSuccess(HttpStatus.OK, "메뉴 삭제 완료");
+    }
+
+    @GetMapping("/{storeId}")
+    @Operation(summary = "해당 가게 메뉴 목록 조회", description = "가게의 메뉴 목록을 조회합니다. 해당 가게의 메뉴를 조회하는 API입니다.")
+    public CustomResponse<List<MenuResponseDTO.MenuListResponseDTO>> getMenusByStore(
+            @PathVariable("storeId") UUID storeId) {
+
+        log.info("가게별 메뉴 조회 요청 - storeId: {}", storeId);
+        List<MenuResponseDTO.MenuListResponseDTO> result = menuQueryService.getMenusByStore(storeId);
+        return CustomResponse.onSuccess(HttpStatus.OK, result);
+    }
+
+    @GetMapping("/top")
+    @Operation(summary = "인기 메뉴 TOP20 조회", description = "인기 메뉴 TOP20을 조회합니다. 인기 메뉴 조회에 사용되는 API입니다.")
+    public CustomResponse<List<MenuResponseDTO.MenuTopResponseDTO>> getTopMenus() {
+        log.info("인기 메뉴 TOP20 조회 요청");
+        List<MenuResponseDTO.MenuTopResponseDTO> result = menuQueryService.getTopMenus();
+        return CustomResponse.onSuccess(HttpStatus.OK, result);
+    }
+
+    @GetMapping("/timetop")
+    @Operation(summary = "시간대별 인기 메뉴 TOP20 조회", description = "시간대별 인기 메뉴 TOP20을 조회합니다. 시간대별 인기 메뉴 조회에 사용되는 API입니다.")
+    public CustomResponse<List<MenuResponseDTO.MenuTimeTopResponseDTO>> getTimeTopMenus() {
+        log.info("시간대별 인기 메뉴 TOP20 조회 요청");
+        List<MenuResponseDTO.MenuTimeTopResponseDTO> result = menuQueryService.getTimeTopMenus();
+        return CustomResponse.onSuccess(HttpStatus.OK, result);
+    }
+
+    @GetMapping("/regiontop")
+    @Operation(summary = "지역별 인기 메뉴 TOP20 조회", description = "지역별 인기 메뉴 TOP20을 조회합니다. 지역별 인기 메뉴 조회에 사용되는 API입니다.")
+    public CustomResponse<List<MenuResponseDTO.MenuRegionTopResponseDTO>> getRegionTopMenus() {
+        log.info("지역별 인기 메뉴 TOP20 조회 요청");
+        List<MenuResponseDTO.MenuRegionTopResponseDTO> result = menuQueryService.getRegionTopMenus();
+        return CustomResponse.onSuccess(HttpStatus.OK, result);
+    }
+
+    @GetMapping("/{menuId}/detail")
+    @Operation(summary = "메뉴 상세 조회", description = "메뉴의 상세 정보를 조회합니다. 메뉴 상세 조회에 사용되는 API입니다.")
+    public CustomResponse<MenuResponseDTO.MenuDetailResponseDTO> getMenuDetail(
+            @PathVariable("menuId") UUID menuId) {
+
+        log.info("메뉴 상세 조회 요청 - menuId: {}", menuId);
+        MenuResponseDTO.MenuDetailResponseDTO result = menuQueryService.getMenuDetail(menuId);
+        return CustomResponse.onSuccess(HttpStatus.OK, result);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
@@ -85,7 +85,7 @@ public class MenuController {
     }
 
     @GetMapping("/{storeId}")
-    @Operation(summary = "해당 ���게 메뉴 목록 조회", description = "가게의 메뉴 목록을 조회합니다. 해당 가게의 메뉴를 조회하는 API입니다.")
+    @Operation(summary = "해당 가게 메뉴 목록 조회", description = "가게의 메뉴 목록을 조회합니다. 해당 가게의 메뉴를 조회하는 API입니다.")
     public CustomResponse<List<MenuResponseDTO.MenuListResponseDTO>> getMenusByStore(
             @PathVariable("storeId") UUID storeId) {
 

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/controller/MenuController.java
@@ -38,14 +38,14 @@ import java.util.UUID;
   - @PathVariable: URL 경로에 변수 매핑
  */
 
-@Slf4j
+@Slf4j // 로그 찍는 기능
 @RestController // API를 요청하면 JSON으로 응답
 @RequiredArgsConstructor    // final 필드를 생성자 주입 방식으로 초기화
 @RequestMapping("/api/menus")   // API의 기본 경로 설정
 @Tag(name = "Menu", description = "메뉴 API by 정병민")  // Swagger에서 사용할 태그
 public class MenuController {
-    private final MenuCommandServiceImpl menuCommandService;
-    private final MenuQueryServiceImpl menuQueryService;
+    private final MenuCommandServiceImpl menuCommandService; // 메뉴 생성/수정/삭제
+    private final MenuQueryServiceImpl menuQueryService; // 메뉴 조회
 
     @PostMapping("")    // 메뉴 생성 API, HTTP POST 메소드 사용
     @Operation(summary = "메뉴 생성", description = "메뉴를 생성합니다. 메뉴 생성에 사용되는 API입니다.")   // Swagger에서 사용할 설명

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/converter/MenuConverter.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/converter/MenuConverter.java
@@ -6,6 +6,7 @@ import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
 
 public class MenuConverter {
 
+    // DTO → Entity 변환
     public static Menu toMenu(MenuRequestDTO.MenuCreateRequestDTO requestDTO) {
         return Menu.builder()
                 .name(requestDTO.getName())
@@ -16,6 +17,7 @@ public class MenuConverter {
                 .build();
     }
 
+    // Entity → 상세응답 DTO 변환
     public static MenuResponseDTO.MenuDetailResponseDTO toMenuDetailResponseDTO(Menu menu) {
         return MenuResponseDTO.MenuDetailResponseDTO.builder()
                 .menuId(menu.getId())
@@ -29,6 +31,7 @@ public class MenuConverter {
                 .build();
     }
 
+    // Entity → 목록응답 DTO 변환
     public static MenuResponseDTO.MenuListResponseDTO toMenuListResponseDTO(Menu menu) {
         return MenuResponseDTO.MenuListResponseDTO.builder()
                 .menuId(menu.getId())
@@ -40,6 +43,7 @@ public class MenuConverter {
                 .build();
     }
 
+    // Entity → 인기 메뉴 TOP20 응답 DTO 변환
     public static MenuResponseDTO.MenuTopResponseDTO toMenuTopResponseDTO(Menu menu) {
         return MenuResponseDTO.MenuTopResponseDTO.builder()
                 .menuId(menu.getId())
@@ -51,6 +55,7 @@ public class MenuConverter {
                 .build();
     }
 
+    // Entity → 시간대별 인기 메뉴 TOP20 응답 DTO 변환
     public static MenuResponseDTO.MenuTimeTopResponseDTO toMenuTimeTopResponseDTO(Menu menu) {
         return MenuResponseDTO.MenuTimeTopResponseDTO.builder()
                 .menuId(menu.getId())
@@ -61,7 +66,7 @@ public class MenuConverter {
                 .category(menu.getMenuCategory() != null ? menu.getMenuCategory().getCategory() : "미분류")
                 .build();
     }
-
+    // Entity → 지역별 인기 메뉴 TOP20 응답 DTO 변환
     public static MenuResponseDTO.MenuRegionTopResponseDTO toMenuRegionTopResponseDTO(Menu menu) {
         return MenuResponseDTO.MenuRegionTopResponseDTO.builder()
                 .menuId(menu.getId())

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/converter/MenuConverter.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/converter/MenuConverter.java
@@ -1,0 +1,75 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.converter;
+
+import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuRequestDTO;
+import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
+
+public class MenuConverter {
+
+    public static Menu toMenu(MenuRequestDTO.MenuCreateRequestDTO requestDTO) {
+        return Menu.builder()
+                .name(requestDTO.getName())
+                .content(requestDTO.getContent())
+                .price(requestDTO.getPrice())
+                .menuPicture(requestDTO.getMenuPicture())
+                .status(requestDTO.getStatus())
+                .build();
+    }
+
+    public static MenuResponseDTO.MenuDetailResponseDTO toMenuDetailResponseDTO(Menu menu) {
+        return MenuResponseDTO.MenuDetailResponseDTO.builder()
+                .menuId(menu.getId())
+                .storeId(menu.getStore() != null ? menu.getStore().getId() : null)
+                .name(menu.getName())
+                .content(menu.getContent())
+                .price(menu.getPrice())
+                .menuPicture(menu.getMenuPicture())
+                .status(menu.getStatus())
+                .category(menu.getMenuCategory() != null ? menu.getMenuCategory().getCategory() : null)
+                .build();
+    }
+
+    public static MenuResponseDTO.MenuListResponseDTO toMenuListResponseDTO(Menu menu) {
+        return MenuResponseDTO.MenuListResponseDTO.builder()
+                .menuId(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .menuPicture(menu.getMenuPicture())
+                .status(menu.getStatus())
+                .category(menu.getMenuCategory() != null ? menu.getMenuCategory().getCategory() : "미분류")
+                .build();
+    }
+
+    public static MenuResponseDTO.MenuTopResponseDTO toMenuTopResponseDTO(Menu menu) {
+        return MenuResponseDTO.MenuTopResponseDTO.builder()
+                .menuId(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .menuPicture(menu.getMenuPicture())
+                .status(menu.getStatus())
+                .category(menu.getMenuCategory() != null ? menu.getMenuCategory().getCategory() : "미분류")
+                .build();
+    }
+
+    public static MenuResponseDTO.MenuTimeTopResponseDTO toMenuTimeTopResponseDTO(Menu menu) {
+        return MenuResponseDTO.MenuTimeTopResponseDTO.builder()
+                .menuId(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .menuPicture(menu.getMenuPicture())
+                .status(menu.getStatus())
+                .category(menu.getMenuCategory() != null ? menu.getMenuCategory().getCategory() : "미분류")
+                .build();
+    }
+
+    public static MenuResponseDTO.MenuRegionTopResponseDTO toMenuRegionTopResponseDTO(Menu menu) {
+        return MenuResponseDTO.MenuRegionTopResponseDTO.builder()
+                .menuId(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .menuPicture(menu.getMenuPicture())
+                .status(menu.getStatus())
+                .category(menu.getMenuCategory() != null ? menu.getMenuCategory().getCategory() : "미분류")
+                .build();
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuRequestDTO.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuRequestDTO.java
@@ -1,0 +1,36 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.dto;
+
+import com.example.cloudfour.peopleofdelivery.domain.menu.enums.MenuStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MenuRequestDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuCreateRequestDTO {
+        private String name;
+        private String content;
+        private Integer price;
+        private String menuPicture;
+        private MenuStatus status;
+        private String category;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuUpdateRequestDTO {
+        private String name;
+        private String content;
+        private Integer price;
+        private String menuPicture;
+        private MenuStatus status;
+        private String category;
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuRequestDTO.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuRequestDTO.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// MenuRequestDTO: 클라이언트 → 서버로 보내는 데이터
 public class MenuRequestDTO {
 
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
+    // 메뉴 생성할 때 필요한 데이터
+    @Getter // Lombok 어노테이션으로 getter 메서드 자동 생성
+    @Builder // 빌더 패턴을 사용하여 객체 생성
+    @NoArgsConstructor // 기본 생성자 자동 생성
+    @AllArgsConstructor // 모든 필드를 매개변수로 받는 생성자 자동 생성
     public static class MenuCreateRequestDTO {
         private String name;
         private String content;
@@ -21,6 +23,7 @@ public class MenuRequestDTO {
         private String category;
     }
 
+    // 메뉴 수정할 때 필요한 데이터
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuResponseDTO.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuResponseDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.UUID;
 
+// MenuResponseDTO: 서버 → 클라이언트로 보내는 데이터
 public class MenuResponseDTO {
 
     // 메뉴 생성 응답

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuResponseDTO.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/dto/MenuResponseDTO.java
@@ -1,0 +1,84 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.dto;
+
+import com.example.cloudfour.peopleofdelivery.domain.menu.enums.MenuStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+public class MenuResponseDTO {
+
+    // 메뉴 생성 응답
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuDetailResponseDTO {
+        private UUID menuId;
+        private UUID storeId;
+        private String name;
+        private String content;
+        private Integer price;
+        private String menuPicture;
+        private MenuStatus status;
+        private String category;
+    }
+
+    // 해당 가게 메뉴 목록 조회 응답
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuListResponseDTO {
+        private UUID menuId;
+        private String name;
+        private Integer price;
+        private String menuPicture;
+        private MenuStatus status;
+        private String category;
+    }
+
+    // 인기 메뉴 TOP20 조회 응답
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuTopResponseDTO {
+        private UUID menuId;
+        private String name;
+        private Integer price;
+        private String menuPicture;
+        private MenuStatus status;
+        private String category;
+    }
+
+    // 시간대별 인기 메뉴 TOP20 조회 응답
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuTimeTopResponseDTO {
+        private UUID menuId;
+        private String name;
+        private Integer price;
+        private String menuPicture;
+        private MenuStatus status;
+        private String category;
+    }
+
+    // 지역별 인기 메뉴 TOP20 조회 응답
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MenuRegionTopResponseDTO {
+        private UUID menuId;
+        private String name;
+        private Integer price;
+        private String menuPicture;
+        private MenuStatus status;
+        private String category;
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/entity/Menu.java
@@ -83,4 +83,28 @@ public class Menu {
         this.store = store;
         store.getMenus().add(this);
     }
+
+    // 메뉴 정보 업데이트 메서드
+    public void update(String name, String content, Integer price, String menuPicture, MenuStatus status) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+        if (price != null) {
+            this.price = price;
+        }
+        if (menuPicture != null) {
+            this.menuPicture = menuPicture;
+        }
+        if (status != null) {
+            this.status = status;
+        }
+    }
+
+    // 소프트 삭제 메서드 (상태를 숨김으로 변경)
+    public void softDelete() {
+        this.status = MenuStatus.숨김;
+    }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/repository/MenuCategoryRepository.java
@@ -6,4 +6,5 @@ import java.util.UUID;
 
 public interface MenuCategoryRepository extends JpaRepository<MenuCategory, UUID> {
 
+    // 카테고리명으로 조회, 카테고리명 중복 체크, 활성 상태 카테고리만 조회
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/repository/MenuOptionRepository.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/repository/MenuOptionRepository.java
@@ -6,4 +6,5 @@ import java.util.UUID;
 
 public interface MenuOptionRepository extends JpaRepository<MenuCategory, UUID> {
 
+    // 특정 메뉴의 옵션들 조회
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/repository/MenuRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
+
+    // 가게별 활성 메뉴 조회, 가격 범위로 메뉴 검색, 카테고리별 메뉴 조회
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/command/MenuCommandServiceImpl.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/command/MenuCommandServiceImpl.java
@@ -10,20 +10,26 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
-@Service
-@Slf4j
-@RequiredArgsConstructor
-@Transactional
+@Service // 서비스 레이어 어노테이션
+@Slf4j // 로그 찍기 기능
+@RequiredArgsConstructor // 생성자 주입을 위한 어노테이션
+@Transactional // 트랜잭션 관리 어노테이션
 public class MenuCommandServiceImpl {
 
+    // 메뉴 생성
     public MenuResponseDTO.MenuDetailResponseDTO createMenu(MenuRequestDTO.MenuCreateRequestDTO requestDTO, User user) {
+        // 권한 검사, 사업자의 가게 조회, 메뉴명 중복 체크, 이미지 업로드, 메뉴 카테고리 조회 또는 생성, 엔티티 생성 및 저장, 응답 DTO 생성
         return null;
     }
 
+    // 메뉴 수정
     public MenuResponseDTO.MenuDetailResponseDTO updateMenu(UUID menuId, MenuRequestDTO.MenuUpdateRequestDTO requestDTO, User user) {
+        // 메뉴 존재 확인, 권한 체크
         return null;
     }
 
+    // 메뉴 삭제
     public void deleteMenu(UUID menuId, User user) {
+        // 권한 체크, 소프트 삭제
     }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/command/MenuCommandServiceImpl.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/command/MenuCommandServiceImpl.java
@@ -1,146 +1,29 @@
 package com.example.cloudfour.peopleofdelivery.domain.menu.service.command;
 
-import com.example.cloudfour.peopleofdelivery.domain.menu.converter.MenuConverter;
 import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuRequestDTO;
 import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
-import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
-import com.example.cloudfour.peopleofdelivery.domain.menu.entity.MenuCategory;
-import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuErrorCode;
-import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuException;
-import com.example.cloudfour.peopleofdelivery.domain.menu.repository.MenuRepository;
-import com.example.cloudfour.peopleofdelivery.domain.menu.repository.MenuCategoryRepository;
-import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
-import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreErrorCode;
-import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreException;
-import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
-import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserErrorCode;
-import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserException;
-import com.example.cloudfour.peopleofdelivery.domain.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
-@Slf4j
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 public class MenuCommandServiceImpl {
-    private final MenuRepository menuRepository;
-    private final MenuCategoryRepository menuCategoryRepository;
-    private final StoreRepository storeRepository;
-    private final UserRepository userRepository;
 
     public MenuResponseDTO.MenuDetailResponseDTO createMenu(MenuRequestDTO.MenuCreateRequestDTO requestDTO, User user) {
-        // 사용자 검증
-        userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
-
-        // Repository 구현 후 활성화 예정
-        /*
-        Store userStore = storeRepository.findByUserId(user.getId())
-                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
-        */
-
-        // 임시: 첫 번째 가게를 사용 (Repository 구현 전까지)
-        List<Store> stores = storeRepository.findAll();
-        Store userStore = stores.isEmpty() ? null : stores.get(0);
-        if (userStore == null) {
-            throw new StoreException(StoreErrorCode.NOT_FOUND);
-        }
-
-        // Repository 구현 후 활성화 예정
-        /*
-        MenuCategory findMenuCategory = null;
-        if (requestDTO.getCategory() != null) {
-            findMenuCategory = menuCategoryRepository.findByCategory(requestDTO.getCategory())
-                    .orElse(null);
-        }
-        */
-
-        // 임시: 첫 번째 카테고리를 사용 (Repository 구현 전까지)
-        MenuCategory findMenuCategory = null;
-        if (requestDTO.getCategory() != null) {
-            List<MenuCategory> categories = menuCategoryRepository.findAll();
-            findMenuCategory = categories.isEmpty() ? null : categories.get(0);
-        }
-
-        // Menu 엔티티 생성
-        Menu menu = MenuConverter.toMenu(requestDTO);
-        menu.setStore(userStore);
-        if (findMenuCategory != null) {
-            menu.setMenuCategory(findMenuCategory);
-        }
-
-        menuRepository.save(menu);
-
-        log.info("메뉴 생성 완료 - menuId: {}, name: {}, storeId: {}", menu.getId(), menu.getName(), userStore.getId());
-
-        return MenuConverter.toMenuDetailResponseDTO(menu);
+        return null;
     }
 
     public MenuResponseDTO.MenuDetailResponseDTO updateMenu(UUID menuId, MenuRequestDTO.MenuUpdateRequestDTO requestDTO, User user) {
-        // 사용자 검증
-        userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
-
-        // 메뉴 조회 및 검증
-        Menu findMenu = menuRepository.findById(menuId)
-                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND));
-
-        // 메뉴 소유자 검증 (가게 소유자인지 확인)
-        if (!findMenu.getStore().getUser().getId().equals(user.getId())) {
-            throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
-        }
-
-        // 메뉴 카테고리 변경이 있는 경우 처리
-        if (requestDTO.getCategory() != null) {
-            // Repository 구현 후 활성화 예정
-            /*
-            MenuCategory newMenuCategory = menuCategoryRepository.findByCategory(requestDTO.getCategory())
-                    .orElse(null);
-            */
-
-            // 임시: 첫 번째 카테고리를 사용 (Repository 구현 전까지)
-            List<MenuCategory> categories = menuCategoryRepository.findAll();
-            MenuCategory newMenuCategory = categories.isEmpty() ? null : categories.get(0);
-            findMenu.setMenuCategory(newMenuCategory);
-        }
-
-        // 메뉴 정보 업데이트 (엔티티에 update 메서드가 있다고 가정)
-        findMenu.update(
-                requestDTO.getName(),
-                requestDTO.getContent(),
-                requestDTO.getPrice(),
-                requestDTO.getMenuPicture(),
-                requestDTO.getStatus()
-        );
-
-        menuRepository.save(findMenu);
-
-        log.info("메뉴 수정 완료 - menuId: {}, name: {}", findMenu.getId(), findMenu.getName());
-
-        return MenuConverter.toMenuDetailResponseDTO(findMenu);
+        return null;
     }
 
     public void deleteMenu(UUID menuId, User user) {
-        // 사용자 검증
-        userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
-
-        // 메뉴 조회 및 검증
-        Menu findMenu = menuRepository.findById(menuId)
-                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND));
-
-        // 메뉴 소유자 검증 (가게 소유자인지 확인)
-        if (!findMenu.getStore().getUser().getId().equals(user.getId())) {
-            throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
-        }
-
-        // 소프트 삭제 (엔티티에 softDelete 메서드가 있다고 가정)
-        findMenu.softDelete();
-
-        log.info("메뉴 삭제 완료 - menuId: {}, name: {}", findMenu.getId(), findMenu.getName());
     }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/command/MenuCommandServiceImpl.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/command/MenuCommandServiceImpl.java
@@ -1,0 +1,146 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.service.command;
+
+import com.example.cloudfour.peopleofdelivery.domain.menu.converter.MenuConverter;
+import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuRequestDTO;
+import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.MenuCategory;
+import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuException;
+import com.example.cloudfour.peopleofdelivery.domain.menu.repository.MenuRepository;
+import com.example.cloudfour.peopleofdelivery.domain.menu.repository.MenuCategoryRepository;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreException;
+import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
+import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
+import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserException;
+import com.example.cloudfour.peopleofdelivery.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MenuCommandServiceImpl {
+    private final MenuRepository menuRepository;
+    private final MenuCategoryRepository menuCategoryRepository;
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+
+    public MenuResponseDTO.MenuDetailResponseDTO createMenu(MenuRequestDTO.MenuCreateRequestDTO requestDTO, User user) {
+        // 사용자 검증
+        userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // Repository 구현 후 활성화 예정
+        /*
+        Store userStore = storeRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
+        */
+
+        // 임시: 첫 번째 가게를 사용 (Repository 구현 전까지)
+        List<Store> stores = storeRepository.findAll();
+        Store userStore = stores.isEmpty() ? null : stores.get(0);
+        if (userStore == null) {
+            throw new StoreException(StoreErrorCode.NOT_FOUND);
+        }
+
+        // Repository 구현 후 활성화 예정
+        /*
+        MenuCategory findMenuCategory = null;
+        if (requestDTO.getCategory() != null) {
+            findMenuCategory = menuCategoryRepository.findByCategory(requestDTO.getCategory())
+                    .orElse(null);
+        }
+        */
+
+        // 임시: 첫 번째 카테고리를 사용 (Repository 구현 전까지)
+        MenuCategory findMenuCategory = null;
+        if (requestDTO.getCategory() != null) {
+            List<MenuCategory> categories = menuCategoryRepository.findAll();
+            findMenuCategory = categories.isEmpty() ? null : categories.get(0);
+        }
+
+        // Menu 엔티티 생성
+        Menu menu = MenuConverter.toMenu(requestDTO);
+        menu.setStore(userStore);
+        if (findMenuCategory != null) {
+            menu.setMenuCategory(findMenuCategory);
+        }
+
+        menuRepository.save(menu);
+
+        log.info("메뉴 생성 완료 - menuId: {}, name: {}, storeId: {}", menu.getId(), menu.getName(), userStore.getId());
+
+        return MenuConverter.toMenuDetailResponseDTO(menu);
+    }
+
+    public MenuResponseDTO.MenuDetailResponseDTO updateMenu(UUID menuId, MenuRequestDTO.MenuUpdateRequestDTO requestDTO, User user) {
+        // 사용자 검증
+        userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // 메뉴 조회 및 검증
+        Menu findMenu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND));
+
+        // 메뉴 소유자 검증 (가게 소유자인지 확인)
+        if (!findMenu.getStore().getUser().getId().equals(user.getId())) {
+            throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 메뉴 카테고리 변경이 있는 경우 처리
+        if (requestDTO.getCategory() != null) {
+            // Repository 구현 후 활성화 예정
+            /*
+            MenuCategory newMenuCategory = menuCategoryRepository.findByCategory(requestDTO.getCategory())
+                    .orElse(null);
+            */
+
+            // 임시: 첫 번째 카테고리를 사용 (Repository 구현 전까지)
+            List<MenuCategory> categories = menuCategoryRepository.findAll();
+            MenuCategory newMenuCategory = categories.isEmpty() ? null : categories.get(0);
+            findMenu.setMenuCategory(newMenuCategory);
+        }
+
+        // 메뉴 정보 업데이트 (엔티티에 update 메서드가 있다고 가정)
+        findMenu.update(
+                requestDTO.getName(),
+                requestDTO.getContent(),
+                requestDTO.getPrice(),
+                requestDTO.getMenuPicture(),
+                requestDTO.getStatus()
+        );
+
+        menuRepository.save(findMenu);
+
+        log.info("메뉴 수정 완료 - menuId: {}, name: {}", findMenu.getId(), findMenu.getName());
+
+        return MenuConverter.toMenuDetailResponseDTO(findMenu);
+    }
+
+    public void deleteMenu(UUID menuId, User user) {
+        // 사용자 검증
+        userRepository.findById(user.getId()).orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // 메뉴 조회 및 검증
+        Menu findMenu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND));
+
+        // 메뉴 소유자 검증 (가게 소유자인지 확인)
+        if (!findMenu.getStore().getUser().getId().equals(user.getId())) {
+            throw new MenuException(MenuErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 소프트 삭제 (엔티티에 softDelete 메서드가 있다고 가정)
+        findMenu.softDelete();
+
+        log.info("메뉴 삭제 완료 - menuId: {}, name: {}", findMenu.getId(), findMenu.getName());
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/query/MenuQueryServiceImpl.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/query/MenuQueryServiceImpl.java
@@ -1,0 +1,108 @@
+package com.example.cloudfour.peopleofdelivery.domain.menu.service.query;
+
+import com.example.cloudfour.peopleofdelivery.domain.menu.converter.MenuConverter;
+import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
+import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
+import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuException;
+import com.example.cloudfour.peopleofdelivery.domain.menu.repository.MenuRepository;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreException;
+import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuQueryServiceImpl {
+    private final MenuRepository menuRepository;
+    private final StoreRepository storeRepository;
+
+    public List<MenuResponseDTO.MenuListResponseDTO> getMenusByStore(UUID storeId) {
+        // 가게 존재 여부 검증
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
+
+        // Repository 구현 후 활성화 예정
+        /*
+        List<Menu> menus = menuRepository.findByStoreId(storeId);
+        */
+
+        // 임시: 모든 메뉴 조회 (Repository 구현 전까지)
+        List<Menu> menus = menuRepository.findAll();
+
+        log.info("가게별 메뉴 조회 완��� - storeId: {}, 메뉴 개수: {}", storeId, menus.size());
+
+        return menus.stream()
+                .map(MenuConverter::toMenuListResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    public List<MenuResponseDTO.MenuTopResponseDTO> getTopMenus() {
+        // Repository 구현 후 활성화 예정
+        /*
+        List<Menu> menus = menuRepository.findTop20ByOrderByPopularityDesc();
+        */
+
+        // 임시: 모든 메뉴 조회 후 20개 제한 (Repository 구현 전까지)
+        List<Menu> menus = menuRepository.findAll();
+
+        log.info("인기 메뉴 TOP20 조회 완료 - 메뉴 개수: {}", menus.size());
+
+        return menus.stream()
+                .limit(20)
+                .map(MenuConverter::toMenuTopResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    public List<MenuResponseDTO.MenuTimeTopResponseDTO> getTimeTopMenus() {
+        // Repository 구현 후 활성화 예정
+        /*
+        List<Menu> menus = menuRepository.findTop20ByTimePopularity();
+        */
+
+        // 임시: 모든 메뉴 조회 후 20개 제한 (Repository 구현 전까지)
+        List<Menu> menus = menuRepository.findAll();
+
+        log.info("시간대별 인기 메뉴 TOP20 조회 완료 - 메뉴 개수: {}", menus.size());
+
+        return menus.stream()
+                .limit(20)
+                .map(MenuConverter::toMenuTimeTopResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    public List<MenuResponseDTO.MenuRegionTopResponseDTO> getRegionTopMenus() {
+        // Repository 구현 후 활성화 예정
+        /*
+        List<Menu> menus = menuRepository.findTop20ByRegionPopularity();
+        */
+
+        // 임시: 모든 메뉴 조회 후 20개 제한 (Repository 구현 전까지)
+        List<Menu> menus = menuRepository.findAll();
+
+        log.info("지역별 인기 메뉴 TOP20 조회 완료 - 메뉴 개수: {}", menus.size());
+
+        return menus.stream()
+                .limit(20)
+                .map(MenuConverter::toMenuRegionTopResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    public MenuResponseDTO.MenuDetailResponseDTO getMenuDetail(UUID menuId) {
+        Menu findMenu = menuRepository.findById(menuId)
+                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND));
+
+        log.info("메뉴 상세 조회 완료 - menuId: {}, name: {}", findMenu.getId(), findMenu.getName());
+
+        return MenuConverter.toMenuDetailResponseDTO(findMenu);
+    }
+}

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/query/MenuQueryServiceImpl.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/query/MenuQueryServiceImpl.java
@@ -1,14 +1,6 @@
 package com.example.cloudfour.peopleofdelivery.domain.menu.service.query;
 
-import com.example.cloudfour.peopleofdelivery.domain.menu.converter.MenuConverter;
 import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
-import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
-import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuErrorCode;
-import com.example.cloudfour.peopleofdelivery.domain.menu.exception.MenuException;
-import com.example.cloudfour.peopleofdelivery.domain.menu.repository.MenuRepository;
-import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreErrorCode;
-import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreException;
-import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,93 +8,30 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
-@Slf4j
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MenuQueryServiceImpl {
-    private final MenuRepository menuRepository;
-    private final StoreRepository storeRepository;
 
     public List<MenuResponseDTO.MenuListResponseDTO> getMenusByStore(UUID storeId) {
-        // 가게 존재 여부 검증
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
-
-        // Repository 구현 후 활성화 예정
-        /*
-        List<Menu> menus = menuRepository.findByStoreId(storeId);
-        */
-
-        // 임시: 모든 메뉴 조회 (Repository 구현 전까지)
-        List<Menu> menus = menuRepository.findAll();
-
-        log.info("가게별 메뉴 조회 완��� - storeId: {}, 메뉴 개수: {}", storeId, menus.size());
-
-        return menus.stream()
-                .map(MenuConverter::toMenuListResponseDTO)
-                .collect(Collectors.toList());
+        return null;
     }
 
     public List<MenuResponseDTO.MenuTopResponseDTO> getTopMenus() {
-        // Repository 구현 후 활성화 예정
-        /*
-        List<Menu> menus = menuRepository.findTop20ByOrderByPopularityDesc();
-        */
-
-        // 임시: 모든 메뉴 조회 후 20개 제한 (Repository 구현 전까지)
-        List<Menu> menus = menuRepository.findAll();
-
-        log.info("인기 메뉴 TOP20 조회 완료 - 메뉴 개수: {}", menus.size());
-
-        return menus.stream()
-                .limit(20)
-                .map(MenuConverter::toMenuTopResponseDTO)
-                .collect(Collectors.toList());
+        return null;
     }
 
     public List<MenuResponseDTO.MenuTimeTopResponseDTO> getTimeTopMenus() {
-        // Repository 구현 후 활성화 예정
-        /*
-        List<Menu> menus = menuRepository.findTop20ByTimePopularity();
-        */
-
-        // 임시: 모든 메뉴 조회 후 20개 제한 (Repository 구현 전까지)
-        List<Menu> menus = menuRepository.findAll();
-
-        log.info("시간대별 인기 메뉴 TOP20 조회 완료 - 메뉴 개수: {}", menus.size());
-
-        return menus.stream()
-                .limit(20)
-                .map(MenuConverter::toMenuTimeTopResponseDTO)
-                .collect(Collectors.toList());
+        return null;
     }
 
     public List<MenuResponseDTO.MenuRegionTopResponseDTO> getRegionTopMenus() {
-        // Repository 구현 후 활성화 예정
-        /*
-        List<Menu> menus = menuRepository.findTop20ByRegionPopularity();
-        */
-
-        // 임시: 모든 메뉴 조회 후 20개 제한 (Repository 구현 전까지)
-        List<Menu> menus = menuRepository.findAll();
-
-        log.info("지역별 인기 메뉴 TOP20 조회 완료 - 메뉴 개수: {}", menus.size());
-
-        return menus.stream()
-                .limit(20)
-                .map(MenuConverter::toMenuRegionTopResponseDTO)
-                .collect(Collectors.toList());
+        return null;
     }
 
     public MenuResponseDTO.MenuDetailResponseDTO getMenuDetail(UUID menuId) {
-        Menu findMenu = menuRepository.findById(menuId)
-                .orElseThrow(() -> new MenuException(MenuErrorCode.NOT_FOUND));
-
-        log.info("메뉴 상세 조회 완료 - menuId: {}, name: {}", findMenu.getId(), findMenu.getName());
-
-        return MenuConverter.toMenuDetailResponseDTO(findMenu);
+        return null;
     }
 }

--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/query/MenuQueryServiceImpl.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/menu/service/query/MenuQueryServiceImpl.java
@@ -9,28 +9,34 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
-@Service
-@Slf4j
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Service // 서비스 레이어 어노테이션
+@Slf4j // 로그 찍기 기능
+@RequiredArgsConstructor // 생성자 주입을 위한 어노테이션
+@Transactional(readOnly = true) // 트랜잭션 관리 어노테이션
 public class MenuQueryServiceImpl {
 
+    // 특정 가게의 메뉴 목록 조회
     public List<MenuResponseDTO.MenuListResponseDTO> getMenusByStore(UUID storeId) {
+        // 가게 존재 확인, 활성 상태 메뉴만 조회, DTO 변환
         return null;
     }
 
+    // 전체 인기 메뉴 TOP20 조회
     public List<MenuResponseDTO.MenuTopResponseDTO> getTopMenus() {
         return null;
     }
 
+    // 시간대별 인기 메뉴 TOP20 조회
     public List<MenuResponseDTO.MenuTimeTopResponseDTO> getTimeTopMenus() {
         return null;
     }
 
+    // 지역별 인기 메뉴 TOP20 조회
     public List<MenuResponseDTO.MenuRegionTopResponseDTO> getRegionTopMenus() {
         return null;
     }
 
+    // 메뉴 상세 조회
     public MenuResponseDTO.MenuDetailResponseDTO getMenuDetail(UUID menuId) {
         return null;
     }


### PR DESCRIPTION
## 🔘Part

- [x] 메뉴 컨트롤러

- [x] 메뉴 서비스

- [x] 메뉴 컨버터

- [x] 메뉴 엔티티

- [x] 메뉴 DTO


  <br/>
## ➕ 이슈 링크

- #39 

<br/>

## 🔎 작업 내용

- MenuController: 메뉴 생성/수정/삭제/조회 API 엔드포인트 구현

- MenuCommandServiceImpl: 메뉴 CUD 비즈니스 로직 구현
  - 현재 로그인한 점주의 가게에만 메뉴 생성 가능
  - 메뉴 소유자 권한 검증 로직 추가
  - 소프트 삭제 방식 적용 (상태를 숨김으로 변경)
 
- MenuQueryServiceImpl: 메뉴 조회 비즈니스 로직 구현
  - 가게별 메뉴 목록 조회
  - 인기 메뉴/시간대별/지역별 TOP20 조회
  - 메뉴 상세 조회
 
- MenuConverter: Entity-DTO 변환 로직 구현

- Menu 엔티티에 update(), softDelete() 메서드 추가

- MenuRequestDTO, MenuResponseDTO 구조 정의

- Repository는 JpaRepository 기본 메서드만 사용 (커스텀 메서드는 추후 구현 예정)

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
