### PR TITLE
🔨 [REFACTOR] 테스트 코드 디렉토리 구조 분리

### DIFF
--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/TestFixtureFactory.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/TestFixtureFactory.java
@@ -1,4 +1,4 @@
-package com.example.cloudfour.peopleofdelivery.domain;
+package com.example.cloudfour.peopleofdelivery.unit.domain;
 
 import com.example.cloudfour.peopleofdelivery.domain.cart.entity.Cart;
 import com.example.cloudfour.peopleofdelivery.domain.cartitem.entity.CartItem;

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/menu/service/command/MenuCommandServiceImplTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/menu/service/command/MenuCommandServiceImplTest.java
@@ -1,7 +1,7 @@
-package com.example.cloudfour.peopleofdelivery.domain.menu.service.command;
+package com.example.cloudfour.peopleofdelivery.unit.domain.menu.service.command;
 
 // 테스트에 필요한 라이브러리들 import
-import com.example.cloudfour.peopleofdelivery.domain.TestFixtureFactory;
+import com.example.cloudfour.peopleofdelivery.unit.domain.TestFixtureFactory;
 import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuRequestDTO;
 import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
 import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/menu/service/query/MenuQueryServiceImplTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/menu/service/query/MenuQueryServiceImplTest.java
@@ -1,6 +1,6 @@
-package com.example.cloudfour.peopleofdelivery.domain.menu.service.query;
+package com.example.cloudfour.peopleofdelivery.unit.domain.menu.service.query;
 
-import com.example.cloudfour.peopleofdelivery.domain.TestFixtureFactory;
+import com.example.cloudfour.peopleofdelivery.unit.domain.TestFixtureFactory;
 import com.example.cloudfour.peopleofdelivery.domain.menu.dto.MenuResponseDTO;
 import com.example.cloudfour.peopleofdelivery.domain.menu.entity.Menu;
 import com.example.cloudfour.peopleofdelivery.domain.menu.entity.MenuCategory;

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/command/StoreCommandServiceTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/command/StoreCommandServiceTest.java
@@ -1,6 +1,6 @@
-package com.example.cloudfour.peopleofdelivery.domain.store.service.command;
+package com.example.cloudfour.peopleofdelivery.unit.domain.store.service.command;
 
-import com.example.cloudfour.peopleofdelivery.domain.TestFixtureFactory;
+import com.example.cloudfour.peopleofdelivery.unit.domain.TestFixtureFactory;
 import com.example.cloudfour.peopleofdelivery.domain.region.repository.RegionRepository;
 import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreRequestDTO;
 import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreResponseDTO;
@@ -19,7 +19,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/useraddress/entity/UserAddressTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/useraddress/entity/UserAddressTest.java
@@ -1,4 +1,4 @@
-package com.example.cloudfour.peopleofdelivery.domain.useraddress.entity;
+package com.example.cloudfour.peopleofdelivery.unit.domain.useraddress.entity;
 
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.UserAddress;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

- [people_of_dilivery #88 ](https://github.com/goorm-engineers4/people_of_delivery/issues/88)

<br/>

## 🔎 작업 내용

- 기존 test/domain/{domain name} 구조에서 테스트 단위별로 분리
- test/unit/domain/{domain name}
- test/intergration/domain/{domain name}
  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>
