### PR TITLE
🧪 [TEST] 가게 테스트 코드 작성

### DIFF
--- a/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/service/query/StoreQueryService.java
+++ b/src/main/java/com/example/cloudfour/peopleofdelivery/domain/store/service/query/StoreQueryService.java
@@ -2,6 +2,8 @@ package com.example.cloudfour.peopleofdelivery.domain.store.service.query;
 
 import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreResponseDTO;
 import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreException;
 import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
 import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserErrorCode;
 import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserException;
@@ -65,7 +67,7 @@ public class StoreQueryService {
     public StoreResponseDTO.StoreDetailResponseDTO getStoreById(UUID storeId,CustomUserDetails userDetails) {
         userRepository.findById(userDetails.getId()).orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 가게를 찾을 수 없습니다."));
+                .orElseThrow(() -> new StoreException(StoreErrorCode.NOT_FOUND));
         return StoreResponseDTO.StoreDetailResponseDTO.from(store);
     }
 }

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/command/StoreCommandServiceTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/command/StoreCommandServiceTest.java
@@ -1,16 +1,20 @@
 package com.example.cloudfour.peopleofdelivery.unit.domain.store.service.command;
 
-import com.example.cloudfour.peopleofdelivery.fixtures.Factory;
-import com.example.cloudfour.peopleofdelivery.domain.region.repository.RegionRepository;
-import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreRequestDTO;
-import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreResponseDTO;
+import com.example.cloudfour.peopleofdelivery.domain.region.entity.Region;
 import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import com.example.cloudfour.peopleofdelivery.domain.store.entity.StoreCategory;
-import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreCategoryRepository;
-import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreException;
+import com.example.cloudfour.peopleofdelivery.domain.store.service.command.StoreCommandService;
+import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreRequestDTO;
+import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreResponseDTO;
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
 import com.example.cloudfour.peopleofdelivery.domain.user.enums.Role;
-//import com.example.cloudfour.peopleofdelivery.domain.user.enums.LoginType;
+import com.example.cloudfour.peopleofdelivery.domain.region.repository.RegionRepository;
+import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreCategoryRepository;
+import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
+import com.example.cloudfour.peopleofdelivery.domain.user.repository.UserRepository;
+import com.example.cloudfour.peopleofdelivery.fixtures.Factory;
+import com.example.cloudfour.peopleofdelivery.global.auth.userdetails.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +23,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -26,151 +31,428 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class StoreCommandServiceTest {
+    @Mock private UserRepository userRepository;
+    @InjectMocks private StoreCommandService storeCommandService;
+    @Mock private StoreRepository storeRepository;
+    @Mock private RegionRepository regionRepository;
+    @Mock private StoreCategoryRepository storeCategoryRepository;
 
-    @InjectMocks
-    private StoreCommandService storeCommandService;
+            
+    @Test
+    @DisplayName("가게 생성 실패 - 권한 없는 유저(CUSTOMER, RIDER)")
+    void createStore_fail_no_permission() {
+        for (Role role : new Role[]{Role.CUSTOMER, Role.RIDER}) {
+            User user = Factory.createMockUserWithRole(role);
+            CustomUserDetails userDetails = new CustomUserDetails(user);
+                        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 
-    @Mock
-    private StoreRepository storeRepository;
+            StoreRequestDTO.StoreCreateRequestDTO request = StoreRequestDTO.StoreCreateRequestDTO.builder()
+                    .name("김밥천국")
+                    .category("분식")
+                    .build();
 
-    @Mock
-    private RegionRepository regionRepository;
-
-    @Mock
-    private StoreCategoryRepository storeCategoryRepository;
-
+            assertThatThrownBy(() -> storeCommandService.createStore(request, userDetails))
+                    .isInstanceOf(StoreException.class)
+                    .hasMessage("가게에 접근할 수 있는 권한이 없습니다.");
+        }
+    }
 
     @Test
     @DisplayName("가게 생성 실패 - 중복된 이름")
     void createStore_fail_duplicate_name() {
-
-        // given
-        User user = Factory.createMockUserWithAll();
-        StoreCategory category = user.getStores().get(0).getStoreCategory();
-
+        User user = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user)); 
         StoreRequestDTO.StoreCreateRequestDTO request = StoreRequestDTO.StoreCreateRequestDTO.builder()
-                .name("맛있는치킨") // 이미 존재하는 이름
-                .address("서울 강남구 역삼동 123-45")
-                .storePicture("https://cdn.example.com/store.jpg")
-                .phone("02-123-4567")
-                .content("정성 가득한 김밥집")
-                .minPrice(12000)
-                .deliveryTip(3000)
-                .operationHours("10:00 - 22:00")
-                .closedDays("일요일")
-                .regionId(null)
-                .storeCategoryId(category.getId())
+                .name("치킨나라")
+                .category("치킨")
                 .build();
 
-        // when
-        when(storeRepository.existsByName("김밥천국")).thenReturn(true); // mocking: 동일한 이름 존재
+        when(storeRepository.existsByName("치킨나라")).thenReturn(true);
 
-        // then
-        assertThatThrownBy(() -> storeCommandService.createStore(request, user))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 존재하는 가게 이름입니다.");
+        assertThatThrownBy(() -> storeCommandService.createStore(request, userDetails))
+                .isInstanceOf(StoreException.class)
+                .hasMessage("이미 등록된 가게입니다.");
     }
 
-
-
-    @Test // 존재하지 않는 카테고리를 요청하여 가게를 생성하려고 할때.
-    @DisplayName("가게 생성 실패 - 존재하지 않는 가게 카테고리")
-    void createStore_fail_invalid_category() {
-
-        // given
-        User user = Factory.createMockUserWithAll(); // 사용자 mock
-        UUID invalidCategoryId = UUID.randomUUID(); // 존재하지 않는 카테고리 ID
+    @Test
+    @DisplayName("가게 생성 성공 - 카테고리 명이 이미 존재하는 경우 기존 카테고리 재사용")
+    void createStore_use_existing_category() {
+        User user = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        Region region = Factory.createMockRegion();
+        ReflectionTestUtils.setField(region, "id", UUID.randomUUID());
+        StoreCategory existCategory = StoreCategory.builder().category("치킨").build();
+        ReflectionTestUtils.setField(existCategory, "id", UUID.randomUUID());
 
         StoreRequestDTO.StoreCreateRequestDTO request = StoreRequestDTO.StoreCreateRequestDTO.builder()
-                .name("김밥천국")
-                .address("서울 강남구 역삼동 123-45")
-                .storePicture("https://cdn.example.com/store.jpg")
-                .phone("02-123-4567")
-                .content("정성 가득한 김밥집")
-                .minPrice(12000)
-                .deliveryTip(3000)
+                .name("치킨나라")
+                .address("서울 종로구")
+                .storePicture("chicken.jpg")
+                .phone("02-1111-2222")
+                .content("치킨 맛집")
+                .minPrice(15000)
+                .deliveryTip(2000)
                 .operationHours("10:00 - 22:00")
-                .closedDays("일요일")
-                .regionId(null)  // 지역 없이 생성
-                .storeCategoryId(invalidCategoryId)
+                .closedDays("화요일")
+                .regionId(region.getId())
+                .category("치킨")
                 .build();
 
-        // when
-        when(storeCategoryRepository.findById(invalidCategoryId)).thenReturn(Optional.empty()); // mocking: 없는 카테고리 ID를 조회하면 빈 Optional 반환
+        when(regionRepository.findById(region.getId())).thenReturn(Optional.of(region));
+        when(storeCategoryRepository.findByCategory("치킨")).thenReturn(Optional.of(existCategory));
+        when(storeRepository.existsByName(request.getName())).thenReturn(false);
+        when(storeRepository.save(any(Store.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        // when & then
-        assertThatThrownBy(() -> storeCommandService.createStore(request, user))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 카테고리를 찾을 수 없습니다.");
+        StoreResponseDTO.StoreCreateResponseDTO response = storeCommandService.createStore(request, userDetails);
+
+        assertThat(response.getName()).isEqualTo("치킨나라");
+        verify(storeCategoryRepository).findByCategory("치킨");
     }
 
-
-
-    @ParameterizedTest
-    @EnumSource(value = Role.class, names = {"CUSTOMER", "RIDER"})
-    @DisplayName("가게 생성 실패 - 가게 생성 권한없는 유저")
-    void createStore_fail_no_permission(Role role) {
-        // given
-        User user = Factory.createMockUserWithRole(role); // ->  권한 없는 유저
-        StoreCategory category = Factory.createMockStoreCategory();
+    @Test
+    @DisplayName("가게 생성 성공 - 카테고리 명이 없을 경우 새로 생성")
+    void createStore_create_new_category_if_not_exists() {
+        User user = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        Region region = Factory.createMockRegion();
+        ReflectionTestUtils.setField(region, "id", UUID.randomUUID());
+        String newCategoryName = "족발";
 
         StoreRequestDTO.StoreCreateRequestDTO request = StoreRequestDTO.StoreCreateRequestDTO.builder()
-                .name("김밥천국")
-                .address("서울 강남구 역삼동 123-45")
-                .storePicture("https://cdn.example.com/store.jpg")
-                .phone("02-123-4567")
-                .content("정성 가득한 김밥집")
-                .minPrice(12000)
+                .name("족발킹")
+                .address("서울 노원구")
+                .storePicture("jokbal.jpg")
+                .phone("02-5555-1111")
+                .content("족발 전문점")
+                .minPrice(18000)
                 .deliveryTip(3000)
-                .operationHours("10:00 - 22:00")
+                .operationHours("11:00 - 22:00")
                 .closedDays("일요일")
-                .regionId(null)
-                .storeCategoryId(UUID.randomUUID()) // 굳이 의미 없음
+                .regionId(region.getId())
+                .category(newCategoryName)
                 .build();
 
-        // when & then
-        assertThatThrownBy(() -> storeCommandService.createStore(request, user))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("가게를 생성할 권한이 없습니다.");
+        when(regionRepository.findById(region.getId())).thenReturn(Optional.of(region));
+        when(storeCategoryRepository.findByCategory(newCategoryName)).thenReturn(Optional.empty());
+        when(storeCategoryRepository.save(any(StoreCategory.class)))
+                .thenAnswer(invocation -> {
+                    StoreCategory c = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(c, "id", UUID.randomUUID());
+                    return c;
+                });
+        when(storeRepository.existsByName(request.getName())).thenReturn(false);
+        when(storeRepository.save(any(Store.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StoreResponseDTO.StoreCreateResponseDTO response = storeCommandService.createStore(request, userDetails);
+
+        assertThat(response.getName()).isEqualTo("족발킹");
+        verify(storeCategoryRepository).save(any(StoreCategory.class));
     }
 
     @ParameterizedTest
     @EnumSource(value = Role.class, names = {"MASTER", "OWNER"})
-    @DisplayName("가게 생성 성공 - MASTER 유저")
-    void createStore_success_with_master_role(Role role) {
-        // given
-        User user = Factory.createMockUserWithRole(role); // -> 가게 생성 가능 권한
-        StoreCategory category = Factory.createMockStoreCategory();
+    @DisplayName("가게 생성 성공 - 권한 있는 유저")
+    void createStore_success_with_permission(Role role) {
+        User user = Factory.createMockUserWithRole(role);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        Region region = Factory.createMockRegion();
+        ReflectionTestUtils.setField(region, "id", UUID.randomUUID());
+        StoreCategory category = StoreCategory.builder().category("분식").build();
+        ReflectionTestUtils.setField(category, "id", UUID.randomUUID());
 
         StoreRequestDTO.StoreCreateRequestDTO request = StoreRequestDTO.StoreCreateRequestDTO.builder()
-                .name("김밥천국")
-                .address("서울 강남구 역삼동 123-45")
-                .storePicture("https://cdn.example.com/store.jpg")
-                .phone("02-123-4567")
-                .content("정성 가득한 김밥집")
-                .minPrice(12000)
-                .deliveryTip(3000)
-                .operationHours("10:00 - 22:00")
-                .closedDays("일요일")
-                .regionId(null)
-                .storeCategoryId(category.getId())
+                .name("분식천국")
+                .address("서울 중구 명동")
+                .storePicture("bunsik.jpg")
+                .phone("02-3333-4444")
+                .content("명동 분식집")
+                .minPrice(7000)
+                .deliveryTip(1500)
+                .operationHours("09:00 - 21:00")
+                .closedDays("수요일")
+                .regionId(region.getId())
+                .category("분식")
                 .build();
 
-        when(storeCategoryRepository.findById(category.getId())).thenReturn(Optional.of(category)); //mocking
+        when(regionRepository.findById(region.getId())).thenReturn(Optional.of(region));
+        when(storeCategoryRepository.findByCategory("분식")).thenReturn(Optional.of(category));
         when(storeRepository.existsByName(request.getName())).thenReturn(false);
         when(storeRepository.save(any(Store.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        // when
-        StoreResponseDTO.StoreCreateResponseDTO response = storeCommandService.createStore(request, user);
+        StoreResponseDTO.StoreCreateResponseDTO response = storeCommandService.createStore(request, userDetails);
 
-        // then
-        assertThat(response.getName()).isEqualTo("김밥천국");
+        assertThat(response.getName()).isEqualTo("분식천국");
+        assertThat(response.getCategory()).isEqualTo("분식");
+        assertThat(response.getAddress()).isEqualTo("서울 중구 명동");
+    }
+
+            
+    @Test
+    @DisplayName("가게 수정 실패 - 권한 없는 유저")
+    void updateStore_fail_noPermission() {
+        User storeOwner = Factory.createMockUserWithRole(Role.OWNER);
+        User otherUser = Factory.createMockUserWithRole(Role.CUSTOMER);
+
+        UUID storeOwnerId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        ReflectionTestUtils.setField(storeOwner, "id", storeOwnerId);
+        ReflectionTestUtils.setField(otherUser, "id", otherUserId);
+
+        CustomUserDetails otherUserDetails = new CustomUserDetails(otherUser);
+        StoreCategory category = StoreCategory.builder().category("치킨").build();
+        Store store = Store.builder()
+                .id(UUID.randomUUID())
+                .name("김밥천국")
+                .user(storeOwner)
+                .storeCategory(category)
+                .build();
+
+        StoreRequestDTO.StoreUpdateRequestDTO request = StoreRequestDTO.StoreUpdateRequestDTO.builder()
+                .name("수정불가가게")
+                .category("치킨")
+                .build();
+
+        when(userRepository.findById(otherUser.getId())).thenReturn(Optional.of(otherUser));
+        when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
+
+        assertThatThrownBy(() -> storeCommandService.updateStore(store.getId(), request, otherUserDetails))
+                .isInstanceOf(StoreException.class)
+                .hasMessage("가게에 접근할 수 있는 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("가게 수정 실패 - 중복된 가게 이름")
+    void updateStore_fail_duplicateName() {
+        User user = Factory.createMockUserWithRole(Role.MASTER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        StoreCategory category = StoreCategory.builder().category("한식").build();
+        Store store = Store.builder()
+                .id(UUID.randomUUID())
+                .name("김밥천국")
+                .user(user)
+                .storeCategory(category)
+                .build();
+
+        StoreRequestDTO.StoreUpdateRequestDTO request = StoreRequestDTO.StoreUpdateRequestDTO.builder()
+                .name("이미존재하는가게")
+                .address("서울 강남구 역삼동 456-78")
+                .category("한식")
+                .build();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
+        when(storeRepository.existsByName("이미존재하는가게")).thenReturn(true);
+
+        assertThatThrownBy(() -> storeCommandService.updateStore(store.getId(), request, userDetails))
+                .isInstanceOf(StoreException.class)
+                .hasMessage("이미 등록된 가게입니다.");
+    }
+
+    @Test
+    @DisplayName("가게 수정 성공 - 카테고리명 변경(신규)")
+    void updateStore_success_change_category_to_new() {
+                User user = Factory.createMockUserWithRole(Role.OWNER);
+        UUID userId = UUID.randomUUID();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+                CustomUserDetails userDetails = new CustomUserDetails(user);
+
+                StoreCategory oldCategory = StoreCategory.builder().category("분식").build();
+        ReflectionTestUtils.setField(oldCategory, "id", UUID.randomUUID());
+        Store store = Store.builder()
+                .id(UUID.randomUUID())
+                .name("분식왕")
+                .user(user)
+                .storeCategory(oldCategory)
+                .build();
+
+                String newCategoryName = "족발";
+        StoreRequestDTO.StoreUpdateRequestDTO request = StoreRequestDTO.StoreUpdateRequestDTO.builder()
+                .name("족발왕")
+                .address("서울 영등포구")
+                .category(newCategoryName)
+                .build();
+
+                when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
+        when(storeRepository.existsByName("족발왕")).thenReturn(false);
+        when(storeCategoryRepository.findByCategory(newCategoryName)).thenReturn(Optional.empty());
+        when(storeCategoryRepository.save(any(StoreCategory.class)))
+                .thenAnswer(invocation -> {
+                    StoreCategory c = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(c, "id", UUID.randomUUID());
+                    return c;
+                });
+        when(storeRepository.save(any(Store.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+                StoreResponseDTO.StoreUpdateResponseDTO response = storeCommandService.updateStore(store.getId(), request, userDetails);
+
+        assertThat(response.getName()).isEqualTo("족발왕");
+        assertThat(response.getCategory()).isEqualTo("족발");
+        verify(storeCategoryRepository).save(any(StoreCategory.class));
     }
 
 
-}
+    @Test
+    @DisplayName("가게 수정 성공 - 카테고리명 변경(기존)")
+    void updateStore_success_change_category_to_existing() {
+                User user = Factory.createMockUserWithRole(Role.OWNER);
+        UUID userId = UUID.randomUUID();
+        ReflectionTestUtils.setField(user, "id", userId);
 
+                CustomUserDetails userDetails = new CustomUserDetails(user);
+
+                StoreCategory oldCategory = StoreCategory.builder().category("분식").build();
+        ReflectionTestUtils.setField(oldCategory, "id", UUID.randomUUID());
+        StoreCategory existCategory = StoreCategory.builder().category("치킨").build();
+        ReflectionTestUtils.setField(existCategory, "id", UUID.randomUUID());
+
+        Store store = Store.builder()
+                .id(UUID.randomUUID())
+                .name("분식왕")
+                .user(user)
+                .storeCategory(oldCategory)
+                .build();
+
+        StoreRequestDTO.StoreUpdateRequestDTO request = StoreRequestDTO.StoreUpdateRequestDTO.builder()
+                .name("치킨왕")
+                .address("서울 동작구")
+                .category("치킨")
+                .build();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
+        when(storeRepository.existsByName("치킨왕")).thenReturn(false);
+        when(storeCategoryRepository.findByCategory("치킨")).thenReturn(Optional.of(existCategory));
+        when(storeRepository.save(any(Store.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        StoreResponseDTO.StoreUpdateResponseDTO response = storeCommandService.updateStore(store.getId(), request, userDetails);
+
+        assertThat(response.getName()).isEqualTo("치킨왕");
+        assertThat(response.getCategory()).isEqualTo("치킨");
+        verify(storeCategoryRepository).findByCategory("치킨");
+    }
+
+
+    @Test
+    @DisplayName("가게 수정 실패 - 존재하지 않는 가게")
+    void updateStore_fail_storeNotFound() {
+        User user = Factory.createMockUserWithRole(Role.MASTER);
+        UUID userId = UUID.randomUUID();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        UUID storeId = UUID.randomUUID();
+
+        StoreRequestDTO.StoreUpdateRequestDTO request = StoreRequestDTO.StoreUpdateRequestDTO.builder()
+                .name("새로운김밥천국")
+                .address("서울 강남구 역삼동 456-78")
+                .category("한식")
+                .build();
+
+                when(storeRepository.findById(storeId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeCommandService.updateStore(storeId, request, userDetails))
+                .isInstanceOf(StoreException.class)
+                .hasMessage("가게를 찾을 수 없습니다.");
+    }
+
+
+
+            
+    @Test
+    @DisplayName("가게 삭제 성공 - 마스터")
+    void deleteStore_success_master() {
+        User master = Factory.createMockUserWithRole(Role.MASTER);
+        CustomUserDetails masterDetails = new CustomUserDetails(master);
+        StoreCategory category = StoreCategory.builder().category("족발").build();
+        Store store = Store.builder()
+                .id(UUID.randomUUID())
+                .name("족발킹")
+                .user(master)
+                .storeCategory(category)
+                .build();
+
+        when(userRepository.findById(master.getId())).thenReturn(Optional.of(master));
+        when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
+        when(storeRepository.existsByStoreAndUser(store.getId(), master.getId())).thenReturn(true);
+        when(storeRepository.save(store)).thenReturn(store);
+
+        storeCommandService.deleteStore(store.getId(), masterDetails);
+
+        verify(storeRepository).save(store);
+        assertThat(store.getIsDeleted()).isTrue();
+        assertThat(store.getDeletedAt()).isNotNull();
+    }
+
+
+
+    @Test
+    @DisplayName("가게 삭제 성공 - 가게 주인(OWNER)")
+    void deleteStore_success_owner() {
+        User owner = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails ownerDetails = new CustomUserDetails(owner);
+        StoreCategory category = StoreCategory.builder().category("족발").build();
+        Store store = Store.builder()
+                .id(UUID.randomUUID())
+                .name("족발킹")
+                .user(owner)
+                .storeCategory(category)
+                .build();
+
+        when(userRepository.findById(owner.getId())).thenReturn(Optional.of(owner));
+        when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
+        when(storeRepository.existsByStoreAndUser(store.getId(), owner.getId())).thenReturn(true);
+        when(storeRepository.save(store)).thenReturn(store);
+
+        storeCommandService.deleteStore(store.getId(), ownerDetails);
+
+        verify(storeRepository).save(store);
+        assertThat(store.getIsDeleted()).isTrue();
+        assertThat(store.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("가게 삭제 실패 - 권한 없음(다른 OWNER)")
+    void deleteStore_fail_no_permission() {
+        User storeOwner = Factory.createMockUserWithRole(Role.OWNER);
+        User otherUser = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails otherDetails = new CustomUserDetails(otherUser);
+        StoreCategory category = StoreCategory.builder().category("족발").build();
+        Store store = Store.builder()
+                .id(UUID.randomUUID())
+                .name("족발킹")
+                .user(storeOwner)
+                .storeCategory(category)
+                .build();
+
+        when(userRepository.findById(otherUser.getId())).thenReturn(Optional.of(otherUser));
+        when(storeRepository.findById(store.getId())).thenReturn(Optional.of(store));
+
+        assertThatThrownBy(() -> storeCommandService.deleteStore(store.getId(), otherDetails))
+                .isInstanceOf(StoreException.class)
+                .hasMessage("가게에 접근할 수 있는 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("가게 삭제 실패 - 존재하지 않는 가게")
+    void deleteStore_fail_store_not_found() {
+        User master = Factory.createMockUserWithRole(Role.MASTER);
+        CustomUserDetails masterDetails = new CustomUserDetails(master);
+        UUID storeId = UUID.randomUUID();
+
+        when(storeRepository.findById(storeId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeCommandService.deleteStore(storeId, masterDetails))
+                .isInstanceOf(StoreException.class)
+                .hasMessage("가게를 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/command/StoreCommandServiceTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/command/StoreCommandServiceTest.java
@@ -30,8 +30,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class StoreCommandServiceTest {

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/query/StoreQueryServiceTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/query/StoreQueryServiceTest.java
@@ -1,0 +1,208 @@
+package com.example.cloudfour.peopleofdelivery.unit.domain.store.service.query;
+
+import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreResponseDTO;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.StoreCategory;
+import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
+import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
+import com.example.cloudfour.peopleofdelivery.domain.user.enums.LoginType;
+import com.example.cloudfour.peopleofdelivery.domain.user.enums.Role;
+import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.user.exception.UserException;
+import com.example.cloudfour.peopleofdelivery.domain.user.repository.UserRepository;
+import com.example.cloudfour.peopleofdelivery.domain.store.service.query.StoreQueryService;
+import com.example.cloudfour.peopleofdelivery.global.auth.userdetails.CustomUserDetails;
+import com.example.cloudfour.peopleofdelivery.fixtures.Factory;
+import com.example.cloudfour.peopleofdelivery.global.entity.BaseEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StoreQueryServiceTest {
+
+    @Mock private StoreRepository storeRepository;
+    @Mock private UserRepository userRepository;
+    @InjectMocks private StoreQueryService storeQueryService;
+
+        @Test
+    @DisplayName("키워드로 전체 가게 조회 성공 (nextCursor 반환)")
+    void getAllStores_success() {
+                User user = Factory.createMockUserWithRole(Role.MASTER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        LocalDateTime now = LocalDateTime.now();
+        Store store1 = Store.builder()
+                .id(UUID.randomUUID())
+                .name("김밥천국")
+                .build();
+        ReflectionTestUtils.setField(store1, "createdAt", now.minusMinutes(1));
+
+        Store store2 = Store.builder()
+                .id(UUID.randomUUID())
+                .name("치킨나라")
+                .build();
+        ReflectionTestUtils.setField(store2, "createdAt", now.minusMinutes(2));
+
+        List<Store> stores = List.of(store1, store2);
+        Slice<Store> storeSlice = new SliceImpl<>(stores, PageRequest.of(0, 2), true);
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findAllByKeyWord(anyString(), any(), any(Pageable.class))).thenReturn(storeSlice);
+
+                StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(
+                null, 2, "김밥", userDetails);
+
+                assertThat(response.getStoreList()).hasSize(2);
+        assertThat(response.getNextCursor()).isEqualTo(store2.getCreatedAt());     }
+
+    @Test
+    @DisplayName("키워드로 전체 가게 조회 - store가 없으면 nextCursor=null")
+    void getAllStores_empty() {
+                User user = Factory.createMockUserWithRole(Role.MASTER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        Slice<Store> storeSlice = new SliceImpl<>(Collections.emptyList(), PageRequest.of(0, 2), false);
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findAllByKeyWord(anyString(), any(), any(Pageable.class))).thenReturn(storeSlice);
+
+                StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(
+                null, 2, "없는가게", userDetails);
+
+                assertThat(response.getStoreList()).isEmpty();
+        assertThat(response.getNextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("키워드로 전체 가게 조회 실패 - 존재하지 않는 유저")
+    void getAllStores_userNotFound() {
+                CustomUserDetails userDetails = CustomUserDetails.of(UUID.randomUUID(), "fake@email.com", Role.MASTER, LoginType.LOCAL);
+        when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> storeQueryService.getAllStores(null, 2, "김밥", userDetails))
+                .isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_FOUND.getMessage());
+    }
+
+        @Test
+    @DisplayName("카테고리별 가게 조회 성공")
+    void getStoresByCategory_success() {
+                User user = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        UUID categoryId = UUID.randomUUID();
+        LocalDateTime now = LocalDateTime.now();
+        Store store1 = Store.builder()
+                .id(UUID.randomUUID())
+                .name("분식왕")
+                .build();
+        ReflectionTestUtils.setField(store1, "createdAt", now.minusMinutes(3));
+
+        List<Store> stores = List.of(store1);
+        Slice<Store> storeSlice = new SliceImpl<>(stores, PageRequest.of(0, 1), false);
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findAllByCategoryAndCursor(eq(categoryId), any(), any(Pageable.class)))
+                .thenReturn(storeSlice);
+
+                StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getStoresByCategory(
+                categoryId, null, 1, userDetails);
+
+                assertThat(response.getStoreList()).hasSize(1);
+        assertThat(response.getNextCursor()).isNull();     }
+
+    @Test
+    @DisplayName("카테고리별 가게 조회 실패 - 존재하지 않는 유저")
+    void getStoresByCategory_userNotFound() {
+        CustomUserDetails userDetails =
+                CustomUserDetails.of(UUID.randomUUID(), "email", Role.OWNER, LoginType.LOCAL);
+
+        when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                storeQueryService.getStoresByCategory(UUID.randomUUID(), null, 1, userDetails)
+        ).isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_FOUND.getMessage());
+    }
+
+        @Test
+    @DisplayName("단일 가게 상세조회 성공")
+    void getStoreById_success() throws Exception {          User user = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        UUID storeId = UUID.randomUUID();
+
+                StoreCategory category = StoreCategory.builder()
+                .category("일식")
+                .build();
+
+                java.lang.reflect.Field idField = StoreCategory.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(category, UUID.randomUUID());
+
+        Store store = Store.builder()
+                .id(storeId)
+                .name("스시천국")
+                .storeCategory(category)                  .build();
+        Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
+        createdAtField.setAccessible(true);
+        createdAtField.set(store, LocalDateTime.now());
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findById(storeId)).thenReturn(Optional.of(store));
+
+        StoreResponseDTO.StoreDetailResponseDTO response = storeQueryService.getStoreById(storeId, userDetails);
+
+        assertThat(response.getName()).isEqualTo("스시천국");
+        assertThat(response.getStoreId()).isEqualTo(storeId);
+    }
+
+
+
+    @Test
+    @DisplayName("단일 가게 상세조회 실패 - 유저 없음")
+    void getStoreById_userNotFound() {
+        CustomUserDetails userDetails =
+                CustomUserDetails.of(UUID.randomUUID(), "email", Role.OWNER, LoginType.LOCAL);
+
+        when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                storeQueryService.getStoreById(UUID.randomUUID(), userDetails)
+        ).isInstanceOf(UserException.class)
+                .hasMessage(UserErrorCode.NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("단일 가게 상세조회 실패 - 가게 없음")
+    void getStoreById_storeNotFound() {
+        User user = Factory.createMockUserWithRole(Role.OWNER);
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        UUID storeId = UUID.randomUUID();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(storeRepository.findById(storeId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                storeQueryService.getStoreById(storeId, userDetails)
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 가게를 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/query/StoreQueryServiceTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/query/StoreQueryServiceTest.java
@@ -3,6 +3,8 @@ package com.example.cloudfour.peopleofdelivery.unit.domain.store.service.query;
 import com.example.cloudfour.peopleofdelivery.domain.store.dto.StoreResponseDTO;
 import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
 import com.example.cloudfour.peopleofdelivery.domain.store.entity.StoreCategory;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreErrorCode;
+import com.example.cloudfour.peopleofdelivery.domain.store.exception.StoreException;
 import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
 import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
 import com.example.cloudfour.peopleofdelivery.domain.user.enums.LoginType;
@@ -211,7 +213,7 @@ class StoreQueryServiceTest {
 
         assertThatThrownBy(() ->
                 storeQueryService.getStoreById(storeId, userDetails)
-        ).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("해당 가게를 찾을 수 없습니다.");
+        ).isInstanceOf(StoreException.class)
+                .hasMessage(StoreErrorCode.NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/query/StoreQueryServiceTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/service/query/StoreQueryServiceTest.java
@@ -33,8 +33,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(MockitoExtension.class)
 class StoreQueryServiceTest {
@@ -43,7 +47,7 @@ class StoreQueryServiceTest {
     @Mock private UserRepository userRepository;
     @InjectMocks private StoreQueryService storeQueryService;
 
-        @Test
+    @Test
     @DisplayName("키워드로 전체 가게 조회 성공 (nextCursor 반환)")
     void getAllStores_success() {
                 User user = Factory.createMockUserWithRole(Role.MASTER);
@@ -68,11 +72,12 @@ class StoreQueryServiceTest {
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(storeRepository.findAllByKeyWord(anyString(), any(), any(Pageable.class))).thenReturn(storeSlice);
 
-                StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(
-                null, 2, "김밥", userDetails);
+        StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(
+        null, 2, "김밥", userDetails);
 
-                assertThat(response.getStoreList()).hasSize(2);
-        assertThat(response.getNextCursor()).isEqualTo(store2.getCreatedAt());     }
+        assertThat(response.getStoreList()).hasSize(2);
+        assertThat(response.getNextCursor()).isEqualTo(store2.getCreatedAt());
+    }
 
     @Test
     @DisplayName("키워드로 전체 가게 조회 - store가 없으면 nextCursor=null")
@@ -84,10 +89,10 @@ class StoreQueryServiceTest {
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(storeRepository.findAllByKeyWord(anyString(), any(), any(Pageable.class))).thenReturn(storeSlice);
 
-                StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(
-                null, 2, "없는가게", userDetails);
+        StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getAllStores(
+        null, 2, "없는가게", userDetails);
 
-                assertThat(response.getStoreList()).isEmpty();
+        assertThat(response.getStoreList()).isEmpty();
         assertThat(response.getNextCursor()).isNull();
     }
 
@@ -102,7 +107,8 @@ class StoreQueryServiceTest {
                 .hasMessage(UserErrorCode.NOT_FOUND.getMessage());
     }
 
-        @Test
+
+    @Test
     @DisplayName("카테고리별 가게 조회 성공")
     void getStoresByCategory_success() {
                 User user = Factory.createMockUserWithRole(Role.OWNER);
@@ -123,10 +129,10 @@ class StoreQueryServiceTest {
         when(storeRepository.findAllByCategoryAndCursor(eq(categoryId), any(), any(Pageable.class)))
                 .thenReturn(storeSlice);
 
-                StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getStoresByCategory(
-                categoryId, null, 1, userDetails);
+        StoreResponseDTO.StoreCursorListResponseDTO response = storeQueryService.getStoresByCategory(
+        categoryId, null, 1, userDetails);
 
-                assertThat(response.getStoreList()).hasSize(1);
+        assertThat(response.getStoreList()).hasSize(1);
         assertThat(response.getNextCursor()).isNull();     }
 
     @Test
@@ -143,24 +149,27 @@ class StoreQueryServiceTest {
                 .hasMessage(UserErrorCode.NOT_FOUND.getMessage());
     }
 
-        @Test
+    @Test
     @DisplayName("단일 가게 상세조회 성공")
-    void getStoreById_success() throws Exception {          User user = Factory.createMockUserWithRole(Role.OWNER);
+    void getStoreById_success() throws Exception {
+        User user = Factory.createMockUserWithRole(Role.OWNER);
         CustomUserDetails userDetails = new CustomUserDetails(user);
         UUID storeId = UUID.randomUUID();
 
-                StoreCategory category = StoreCategory.builder()
-                .category("일식")
-                .build();
+        StoreCategory category = StoreCategory.builder()
+            .category("일식")
+            .build();
 
-                java.lang.reflect.Field idField = StoreCategory.class.getDeclaredField("id");
+        java.lang.reflect.Field idField = StoreCategory.class.getDeclaredField("id");
         idField.setAccessible(true);
         idField.set(category, UUID.randomUUID());
 
         Store store = Store.builder()
-                .id(storeId)
-                .name("스시천국")
-                .storeCategory(category)                  .build();
+            .id(storeId)
+            .name("스시천국")
+            .storeCategory(category)
+            .build();
+
         Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
         createdAtField.setAccessible(true);
         createdAtField.set(store, LocalDateTime.now());
@@ -180,7 +189,7 @@ class StoreQueryServiceTest {
     @DisplayName("단일 가게 상세조회 실패 - 유저 없음")
     void getStoreById_userNotFound() {
         CustomUserDetails userDetails =
-                CustomUserDetails.of(UUID.randomUUID(), "email", Role.OWNER, LoginType.LOCAL);
+            CustomUserDetails.of(UUID.randomUUID(), "email", Role.OWNER, LoginType.LOCAL);
 
         when(userRepository.findById(any())).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## 🔘Part

- [x] BE

  <br/>
## ➕ 이슈 링크

#98 

<br/>

## 🔎 작업 내용
- StoreCommandServiceTest
    - 가게 생성, 수정, 삭제 기능에 대한 단위 테스트를 각각 구현
    - 권한이 OWNER, MASTER인 경우와 CUSTOMER, RIDER인 경우에 따라 동작이 다르게 처리되는지 테스트
    - 가게 생성 시, 이미 존재하는 가게 이름이 입력된 경우 중복으로 인해 예외가 발생하는지 테스트
    - 가게 생성 시, 이미 존재하는 카테고리가 있으면 재사용하고, 없으면 새로운 카테고리를 생성하는 로직을 검증
    - 가게를 생성·수정·삭제할 때 권한이 없는 유저(CUSTOMER, RIDER 또는 가게의 OWNER가 아닌 사용자)가 요청하면 예외가 발생하는지 테스트
    - 가게 수정 시, 이미 등록된 가게 이름으로 변경하려고 할 때 예외가 발생하는지 검증
    - 가게 수정 시, 기존에 존재하지 않는 카테고리 이름으로 변경하면 카테고리가 새로 생성되는지, 기존 카테고리로 변경하면 정상적으로 반영되는지 검증
    - 가게 수정 또는 삭제 요청 시, 대상 가게가 존재하지 않는 경우 예외가 발생하는지 검증
    - 가게 삭제 시, 실제로 DB에서 물리적으로 삭제하지 않고 soft delete(논리 삭제)가 정상적으로 수행되고, 삭제 시각이 기록되는지 확인
    - 모든 예외 상황에 대해 StoreException 또는 예상되는 커스텀 예외가 발생하는지 검증

- StoreQueryServiceTest
    - 전체 가게 조회 기능에 대한 단위 테스트 구현 (키워드 검색, 페이징 적용, nextCursor 반환 포함)
    - 카테고리별 가게 조회 기능에 대한 단위 테스트 구현 (카테고리 ID별, 페이징, nextCursor)
    - 단일 가게 상세 조회 기능에 대한 단위 테스트 구현 (storeId 기준)
    - 전체/카테고리별 조회 시, 결과가 없는 경우 storeList가 비어있고 nextCursor가 null인지 검증
    - 전체/카테고리별/단일 조회 요청 시, 요청한 유저가 실제로 존재하지 않을 때 UserException이 발생하는지 검증
    - 단일 가게 상세 조회 시, 요청한 가게가 존재하지 않으면 IllegalArgumentException이 발생하는지 검증
    - 페이징이 필요한 테스트에서 Slice 객체를 이용하여, hasNext()가 true/false일 때 nextCursor가 올바르게 반환되는지 검증



  <br/>

## 이미지 첨부
<img width="593" height="234" alt="image" src="https://github.com/user-attachments/assets/0df3f64b-9a13-42ad-b9fc-372f246d8d1b" />

<img width="962" height="808" alt="image" src="https://github.com/user-attachments/assets/c94b67ae-2133-49e1-983f-7d0fd6b799df" />


<img width="941" height="557" alt="image" src="https://github.com/user-attachments/assets/8c78b80f-6331-459a-9c1f-689d6b7a7589" />



<br/>
