### PR TITLE
🧪 [TEST] : 가게 레포지터리 TDD 구현

### DIFF
--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/repository/StoreCategoryRepository.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/repository/StoreCategoryRepository.java
@@ -1,0 +1,205 @@
+package com.example.cloudfour.peopleofdelivery.unit.domain.store.repository;
+
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.StoreCategory;
+import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreCategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@DisplayName("매장 카테고리 레포지토리 테스트")
+class StoreCategoryRepositoryTest {
+
+    @Autowired
+    private StoreCategoryRepository storeCategoryRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private StoreCategory koreanCategory;
+
+    @BeforeEach
+    void setUp() {
+        
+        koreanCategory = StoreCategory.builder()
+                .category("한식")
+                .build();
+
+        StoreCategory chineseCategory = StoreCategory.builder()
+                .category("중식")
+                .build();
+
+        StoreCategory westernCategory = StoreCategory.builder()
+                .category("양식")
+                .build();
+
+        entityManager.persistAndFlush(koreanCategory);
+        entityManager.persistAndFlush(chineseCategory);
+        entityManager.persistAndFlush(westernCategory);
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("카테고리명으로 매장 카테고리 조회 - 존재하는 경우")
+    void findByCategory_ExistsSuccess() {
+        
+        Optional<StoreCategory> result = storeCategoryRepository.findByCategory("한식");
+
+        
+        assertThat(result).isPresent();
+        assertThat(result.get().getCategory()).isEqualTo("한식");
+        assertThat(result.get().getId()).isEqualTo(koreanCategory.getId());
+    }
+
+    @Test
+    @DisplayName("카테고리명으로 매장 카테고리 조회 - 존재하지 않는 경우")
+    void findByCategory_NotExists() {
+        
+        Optional<StoreCategory> result = storeCategoryRepository.findByCategory("일식");
+
+        
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("카테고리명으로 매장 카테고리 조회 - 대소문자 구분")
+    void findByCategory_CaseSensitive() {
+        
+        Optional<StoreCategory> result1 = storeCategoryRepository.findByCategory("한식");
+        Optional<StoreCategory> result2 = storeCategoryRepository.findByCategory("HANSHIK");
+
+        
+        assertThat(result1).isPresent();
+        assertThat(result2).isEmpty();
+    }
+
+    @Test
+    @DisplayName("모든 매장 카테고리 조회")
+    void findAll_Success() {
+        
+        List<StoreCategory> categories = storeCategoryRepository.findAll();
+
+        
+        assertThat(categories).hasSize(3);
+        assertThat(categories).extracting("category")
+                .containsExactlyInAnyOrder("한식", "중식", "양식");
+    }
+
+    @Test
+    @DisplayName("매장 카테고리 저장")
+    void save_Success() {
+        
+        StoreCategory newCategory = StoreCategory.builder()
+                .category("일식")
+                .build();
+
+        
+        StoreCategory savedCategory = storeCategoryRepository.save(newCategory);
+
+        
+        assertThat(savedCategory.getId()).isNotNull();
+        assertThat(savedCategory.getCategory()).isEqualTo("일식");
+
+        
+        Optional<StoreCategory> foundCategory = storeCategoryRepository.findByCategory("일식");
+        assertThat(foundCategory).isPresent();
+        assertThat(foundCategory.get().getId()).isEqualTo(savedCategory.getId());
+    }
+
+    @Test
+    @DisplayName("매장 카테고리 삭제")
+    void delete_Success() {
+        
+        long initialCount = storeCategoryRepository.count();
+
+        
+        storeCategoryRepository.delete(koreanCategory);
+
+        
+        long finalCount = storeCategoryRepository.count();
+        assertThat(finalCount).isEqualTo(initialCount - 1);
+
+        Optional<StoreCategory> deletedCategory = storeCategoryRepository.findByCategory("한식");
+        assertThat(deletedCategory).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재 여부 확인 - ID로")
+    void existsById_Success() {
+        
+        boolean exists = storeCategoryRepository.existsById(koreanCategory.getId());
+        boolean notExists = storeCategoryRepository.existsById(java.util.UUID.randomUUID());
+
+        
+        assertThat(exists).isTrue();
+        assertThat(notExists).isFalse();
+    }
+
+    @Test
+    @DisplayName("매장 카테고리 수정")
+    void update_Success() {
+        
+        StoreCategory categoryToUpdate = storeCategoryRepository.findByCategory("한식").orElseThrow();
+
+        
+        entityManager.getEntityManager()
+                .createQuery("UPDATE StoreCategory sc SET sc.category = :newCategory WHERE sc.id = :id")
+                .setParameter("newCategory", "전통한식")
+                .setParameter("id", categoryToUpdate.getId())
+                .executeUpdate();
+        entityManager.flush();
+
+        
+        Optional<StoreCategory> foundCategory = storeCategoryRepository.findByCategory("전통한식");
+        assertThat(foundCategory).isPresent();
+        assertThat(foundCategory.get().getId()).isEqualTo(categoryToUpdate.getId());
+
+        Optional<StoreCategory> oldCategory = storeCategoryRepository.findByCategory("한식");
+        assertThat(oldCategory).isEmpty();
+    }
+
+    @Test
+    @DisplayName("중복된 카테고리명 저장 시도")
+    void save_DuplicateCategory() {
+        
+        StoreCategory duplicateCategory = StoreCategory.builder()
+                .category("한식")
+                .build();
+
+        
+        
+        StoreCategory savedCategory = storeCategoryRepository.save(duplicateCategory);
+        assertThat(savedCategory.getId()).isNotNull();
+        assertThat(savedCategory.getCategory()).isEqualTo("한식");
+    }
+
+    @Test
+    @DisplayName("빈 문자열로 카테고리 조회")
+    void findByCategory_EmptyString() {
+        
+        Optional<StoreCategory> result = storeCategoryRepository.findByCategory("");
+
+        
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("null로 카테고리 조회")
+    void findByCategory_Null() {
+        
+        Optional<StoreCategory> result = storeCategoryRepository.findByCategory(null);
+
+        
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/example/cloudfour/peopleofdelivery/unit/domain/store/repository/StoreRepositoryTest.java
@@ -1,0 +1,343 @@
+package com.example.cloudfour.peopleofdelivery.unit.domain.store.repository;
+
+import com.example.cloudfour.peopleofdelivery.domain.region.entity.Region;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.Store;
+import com.example.cloudfour.peopleofdelivery.domain.store.entity.StoreCategory;
+import com.example.cloudfour.peopleofdelivery.domain.store.repository.StoreRepository;
+import com.example.cloudfour.peopleofdelivery.domain.user.entity.User;
+import com.example.cloudfour.peopleofdelivery.domain.user.enums.LoginType;
+import com.example.cloudfour.peopleofdelivery.domain.user.enums.Role;
+import com.example.cloudfour.peopleofdelivery.fixtures.Factory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@DisplayName("매장 레포지토리 테스트")
+class StoreRepositoryTest {
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private User ownerUser;
+    private User deletedUser;
+    private Store mainStore;
+    private StoreCategory koreanCategory;
+    private StoreCategory chineseCategory;
+    private Region region;
+
+    @BeforeEach
+    void setUp() {
+        
+        region = Factory.createMockRegion();
+        entityManager.persistAndFlush(region);
+
+        
+        koreanCategory = Factory.createMockStoreCategory();
+        chineseCategory = StoreCategory.builder()
+                .category("중식")
+                .build();
+        entityManager.persistAndFlush(koreanCategory);
+        entityManager.persistAndFlush(chineseCategory);
+
+        
+        ownerUser = Factory.createMockUserWithRole(Role.OWNER, region);
+        entityManager.persistAndFlush(ownerUser);
+
+        
+        deletedUser = User.builder()
+                .email("deleted@example.com")
+                .nickname("삭제된사장")
+                .number("010-9999-9999")
+                .password("password")
+                .role(Role.OWNER)
+                .loginType(LoginType.LOCAL)
+                .emailVerified(true)
+                .build();
+        entityManager.persistAndFlush(deletedUser);
+
+        
+        entityManager.getEntityManager()
+                .createQuery("UPDATE User u SET u.isDeleted = true WHERE u.id = :id")
+                .setParameter("id", deletedUser.getId())
+                .executeUpdate();
+        entityManager.flush();
+
+        
+        mainStore = Store.builder()
+                .name("메인 한식집")
+                .address("서울시 강남구 역삼동")
+                .phone("02-1234-5678")
+                .content("정통 한식을 맛볼 수 있는 곳")
+                .minPrice(15000)
+                .deliveryTip(3000)
+                .operationHours("11:00-22:00")
+                .closedDays("연중무휴")
+                .user(ownerUser)
+                .storeCategory(koreanCategory)
+                .region(region)
+                .build();
+        entityManager.persistAndFlush(mainStore);
+
+        
+        Store deletedUserStore = Store.builder()
+                .name("삭제된 매장")
+                .address("서울시 강남구 삼성동")
+                .phone("02-3333-3333")
+                .content("삭제된 사용자의 매장")
+                .minPrice(20000)
+                .deliveryTip(4000)
+                .operationHours("12:00-23:00")
+                .closedDays("일요일")
+                .user(deletedUser)
+                .storeCategory(koreanCategory)
+                .region(region)
+                .build();
+        entityManager.persistAndFlush(deletedUserStore);
+
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 매장 조회 - 존재하는 경우")
+    void findByUserId_ExistsSuccess() {
+        
+        Optional<Store> result = storeRepository.findByUserId(ownerUser.getId());
+
+        
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo("메인 한식집");
+        assertThat(result.get().getUser().getId()).isEqualTo(ownerUser.getId());
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 매장 조회 - 존재하지 않는 경우")
+    void findByUserId_NotExists() {
+        
+        Optional<Store> result = storeRepository.findByUserId(java.util.UUID.randomUUID());
+
+        
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 매장 조회 - 삭제된 사용자")
+    void findByUserId_DeletedUser() {
+        
+        Optional<Store> result = storeRepository.findByUserId(deletedUser.getId());
+
+        
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("매장명 중복 확인 - 존재하는 경우")
+    void existsByName_ExistsTrue() {
+        
+        boolean exists = storeRepository.existsByName("메인 한식집");
+
+        
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("매장명 중복 확인 - 존재하지 않는 경우")
+    void existsByName_ExistsFalse() {
+        
+        boolean exists = storeRepository.existsByName("존재하지않는매장");
+
+        
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("ID로 삭제되지 않은 매장 조회 - 존재하는 경우")
+    void findByIdAndIsDeletedFalse_ExistsSuccess() {
+        
+        Optional<Store> result = storeRepository.findByIdAndIsDeletedFalse(mainStore.getId());
+
+        
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo("메인 한식집");
+    }
+
+    @Test
+    @DisplayName("ID로 삭제되지 않은 매장 조회 - 존재하지 않는 경우")
+    void findByIdAndIsDeletedFalse_NotExists() {
+        
+        Optional<Store> result = storeRepository.findByIdAndIsDeletedFalse(java.util.UUID.randomUUID());
+
+        
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("매장과 사용자 존재 확인 - 존재하는 경우")
+    void existsByStoreAndUser_ExistsTrue() {
+        
+        boolean exists = storeRepository.existsByStoreAndUser(mainStore.getId(), ownerUser.getId());
+
+        
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("매장과 사용자 존재 확인 - 존재하지 않는 경우")
+    void existsByStoreAndUser_ExistsFalse() {
+        
+        boolean exists = storeRepository.existsByStoreAndUser(mainStore.getId(), java.util.UUID.randomUUID());
+
+        
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("매장과 사용자 존재 확인 - 삭제된 사용자")
+    void existsByStoreAndUser_DeletedUser() {
+        
+        boolean exists = storeRepository.existsByStoreAndUser(mainStore.getId(), deletedUser.getId());
+
+        
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    @DisplayName("카테고리별 매장 페이징 조회")
+    void findAllByCategoryAndCursor_Success() {
+        
+        LocalDateTime cursor = LocalDateTime.now().plusMinutes(1);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        
+        Slice<Store> storeSlice = storeRepository.findAllByCategoryAndCursor(
+                koreanCategory.getId(), cursor, pageable);
+
+        
+        assertThat(storeSlice.getContent()).hasSize(2); 
+        assertThat(storeSlice.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("키워드로 매장 검색 - 매장명으로 검색")
+    void findAllByKeyWord_SearchByStoreName() {
+        
+        LocalDateTime cursor = LocalDateTime.now().plusMinutes(1);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        
+        Slice<Store> storeSlice = storeRepository.findAllByKeyWord("한식", cursor, pageable);
+
+        
+        assertThat(storeSlice.getContent()).hasSize(1); 
+        assertThat(storeSlice.getContent()).extracting("name").contains("메인 한식집");
+    }
+
+    @Test
+    @DisplayName("키워드로 매장 검색 - 카테고리명으로 검색")
+    void findAllByKeyWord_SearchByCategory() {
+        
+        
+        Store chineseStore = Store.builder()
+                .name("중국집")
+                .address("서울시 강남구 논현동")
+                .phone("02-2222-2222")
+                .content("맛있는 중식요리")
+                .minPrice(12000)
+                .deliveryTip(2500)
+                .operationHours("10:00-21:00")
+                .closedDays("월요일")
+                .user(ownerUser)
+                .storeCategory(chineseCategory)
+                .region(region)
+                .build();
+        entityManager.persistAndFlush(chineseStore);
+
+        LocalDateTime cursor = LocalDateTime.now().plusMinutes(1);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        
+        Slice<Store> storeSlice = storeRepository.findAllByKeyWord("중식", cursor, pageable);
+
+        
+        assertThat(storeSlice.getContent()).hasSize(1);
+        assertThat(storeSlice.getContent()).extracting("name").contains("중국집");
+    }
+
+    @Test
+    @DisplayName("키워드로 매장 검색 - 검색 결과 없음")
+    void findAllByKeyWord_NoResults() {
+        
+        LocalDateTime cursor = LocalDateTime.now().plusMinutes(1);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        
+        Slice<Store> storeSlice = storeRepository.findAllByKeyWord("일식", cursor, pageable);
+
+        
+        assertThat(storeSlice.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("매장 저장")
+    void save_Success() {
+        
+        Store newStore = Store.builder()
+                .name("새로운 매장")
+                .address("서울시 강남구 청담동")
+                .phone("02-4444-4444")
+                .content("새로 오픈한 매장")
+                .minPrice(10000)
+                .deliveryTip(2000)
+                .operationHours("09:00-21:00")
+                .closedDays("화요일")
+                .user(ownerUser)
+                .storeCategory(koreanCategory)
+                .region(region)
+                .build();
+
+        
+        Store savedStore = storeRepository.save(newStore);
+
+        
+        assertThat(savedStore.getId()).isNotNull();
+        assertThat(savedStore.getName()).isEqualTo("새로운 매장");
+
+        
+        Optional<Store> foundStore = storeRepository.findByIdAndIsDeletedFalse(savedStore.getId());
+        assertThat(foundStore).isPresent();
+        assertThat(foundStore.get().getName()).isEqualTo("새로운 매장");
+    }
+
+    @Test
+    @DisplayName("매장 삭제")
+    void delete_Success() {
+        
+        long initialCount = storeRepository.count();
+
+        
+        storeRepository.delete(mainStore);
+
+        
+        long finalCount = storeRepository.count();
+        assertThat(finalCount).isEqualTo(initialCount - 1);
+
+        Optional<Store> deletedStore = storeRepository.findByIdAndIsDeletedFalse(mainStore.getId());
+        assertThat(deletedStore).isEmpty();
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x] StoreRepositoryTest
- [x] StoreCategoryRepositoryTest

  <br/>
## ➕ 이슈 링크
#122 


<br/>

## 🔎 작업 내용
- StoreCategoryRepository 및 StoreRepository에 대한 단위 테스트(TDD) 코드 구현
- 매장 카테고리(한식, 중식 등) 및 매장 엔티티에 대해 CRUD 동작 정상 여부 검증
- 기본 CRUD 기능(등록, 조회, 수정, 삭제) 및 예외 상황에 대한 테스트 케이스 작성
- 테스트 환경에서 JPA의 create-drop 옵션을 사용하여 DB 테이블 자동 생성/삭제 적용
- TestEntityManager 활용하여 직접적인 엔티티 저장 및 조회 테스트

  <br/>

## 이미지 첨부

<br/>
